### PR TITLE
OLMIS-730: Reference Data should be Immutable

### DIFF
--- a/src/main/java/org/openlmis/referencedata/repository/FacilityOperatorRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/FacilityOperatorRepository.java
@@ -1,17 +1,16 @@
 package org.openlmis.referencedata.repository;
 
-import org.openlmis.referencedata.domain.Product;
-import org.openlmis.referencedata.domain.Program;
+import org.openlmis.referencedata.domain.Facility;
+import org.openlmis.referencedata.domain.FacilityOperator;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
 
-public interface ProductRepository extends Repository<Product, Integer>
+public interface FacilityOperatorRepository extends Repository<FacilityOperator, Integer>
 {
-    Iterable<Product> findAll(Sort sort);
-    Page<Product> findAll(Pageable pageable);
+    Iterable<FacilityOperator> findAll(Sort sort);
+    Page<FacilityOperator> findAll(Pageable pageable);
 
     //See UserRepository for examples of how we might implement additional endpoints after we know what they should be.
 }

--- a/src/main/java/org/openlmis/referencedata/repository/FacilityRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/FacilityRepository.java
@@ -1,7 +1,19 @@
 package org.openlmis.referencedata.repository;
 
 import org.openlmis.referencedata.domain.Facility;
+import org.openlmis.referencedata.domain.Product;
+import org.openlmis.referencedata.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.rest.core.annotation.RestResource;
 
-public interface FacilityRepository extends CrudRepository<Facility, Integer> {
+public interface FacilityRepository extends Repository<Facility, Integer>
+{
+    Iterable<Facility> findAll(Sort sort);
+    Page<Facility> findAll(Pageable pageable);
+
+    //See UserRepository for examples of how we might implement additional endpoints after we know what they should be.
 }

--- a/src/main/java/org/openlmis/referencedata/repository/FacilityTypeRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/FacilityTypeRepository.java
@@ -1,17 +1,16 @@
 package org.openlmis.referencedata.repository;
 
-import org.openlmis.referencedata.domain.Product;
-import org.openlmis.referencedata.domain.Program;
+import org.openlmis.referencedata.domain.Facility;
+import org.openlmis.referencedata.domain.FacilityType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
 
-public interface ProductRepository extends Repository<Product, Integer>
+public interface FacilityTypeRepository extends Repository<FacilityType, Integer>
 {
-    Iterable<Product> findAll(Sort sort);
-    Page<Product> findAll(Pageable pageable);
+    Iterable<FacilityType> findAll(Sort sort);
+    Page<FacilityType> findAll(Pageable pageable);
 
     //See UserRepository for examples of how we might implement additional endpoints after we know what they should be.
 }

--- a/src/main/java/org/openlmis/referencedata/repository/GeographicLevelRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/GeographicLevelRepository.java
@@ -1,17 +1,16 @@
 package org.openlmis.referencedata.repository;
 
-import org.openlmis.referencedata.domain.Product;
-import org.openlmis.referencedata.domain.Program;
+import org.openlmis.referencedata.domain.Facility;
+import org.openlmis.referencedata.domain.GeographicLevel;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
 
-public interface ProductRepository extends Repository<Product, Integer>
+public interface GeographicLevelRepository extends Repository<GeographicLevel, Integer>
 {
-    Iterable<Product> findAll(Sort sort);
-    Page<Product> findAll(Pageable pageable);
+    Iterable<GeographicLevel> findAll(Sort sort);
+    Page<GeographicLevel> findAll(Pageable pageable);
 
     //See UserRepository for examples of how we might implement additional endpoints after we know what they should be.
 }

--- a/src/main/java/org/openlmis/referencedata/repository/GeographicZoneRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/GeographicZoneRepository.java
@@ -1,17 +1,16 @@
 package org.openlmis.referencedata.repository;
 
-import org.openlmis.referencedata.domain.Product;
-import org.openlmis.referencedata.domain.Program;
+import org.openlmis.referencedata.domain.GeographicLevel;
+import org.openlmis.referencedata.domain.GeographicZone;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.Repository;
 
-public interface ProductRepository extends Repository<Product, Integer>
+public interface GeographicZoneRepository extends Repository<GeographicZone, Integer>
 {
-    Iterable<Product> findAll(Sort sort);
-    Page<Product> findAll(Pageable pageable);
+    Iterable<GeographicZone> findAll(Sort sort);
+    Page<GeographicZone> findAll(Pageable pageable);
 
     //See UserRepository for examples of how we might implement additional endpoints after we know what they should be.
 }

--- a/src/main/java/org/openlmis/referencedata/repository/ProgramRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/ProgramRepository.java
@@ -1,7 +1,17 @@
 package org.openlmis.referencedata.repository;
 
 import org.openlmis.referencedata.domain.Program;
+import org.openlmis.referencedata.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.Repository;
 
-public interface ProgramRepository extends CrudRepository<Program, Integer> {
+public interface ProgramRepository extends Repository<Program, Integer>
+{
+    Iterable<Program> findAll(Sort sort);
+    Page<Program> findAll(Pageable pageable);
+
+    //See UserRepository for examples of how we might implement additional endpoints after we know what they should be.
 }

--- a/src/main/java/org/openlmis/referencedata/repository/UserRepository.java
+++ b/src/main/java/org/openlmis/referencedata/repository/UserRepository.java
@@ -1,7 +1,54 @@
 package org.openlmis.referencedata.repository;
 
+import org.openlmis.referencedata.domain.Facility;
 import org.openlmis.referencedata.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RestResource;
 
-public interface UserRepository extends CrudRepository<User, Integer> {
+
+@RestResource(exported=true)
+public interface UserRepository extends Repository<User, Integer>
+{
+    /*
+        Generate and expose endpoints such as:
+
+        http://127.0.0.1:8080/api/users/
+        http://127.0.0.1:8080/api/users?page={number}&size={number}&sort={number}
+    */
+    Iterable<User> findAll(Sort sort);
+    Page<User> findAll(Pageable pageable);
+
+
+    //Accessible via http://127.0.0.1:8080/api/users/{id}
+    User findOne(Integer id);
+
+    //Accessible via http://127.0.0.1:8080/api/users/search/findByUsername?username={username}
+    Iterable<User> findByUsername(@Param("username") String username);
+
+
+    //Accessible via http://127.0.0.1:8080/api/users/search/findByLastName?lastName={lastName}
+    Iterable<User> findByLastName(@Param("lastName") String lastName);
+    Iterable<User> findByFirstName(@Param("firstName") String firstName);
+
+    //Accessible via http://127.0.0.1:8080/api/users/search/findByFirstNameAndLastName?firstName={firstName}&lastName={lastName}
+    Iterable<User> findByFirstNameAndLastName(@Param("firstName") String firstName, @Param("lastName") String lastName);
+
+    //Accessible via http://127.0.0.1:8080/api/users/search/findByHomeFacility?homeFacility=http://127.0.0.1:8080/api/facilities/{facilityId}
+    Iterable<User> findByHomeFacility(@Param("homeFacility") Facility homeFacilityId);
+
+    //Accessible via http://127.0.0.1:8080/api/users/search/findByActive?active={active}
+    Iterable<User> findByActive(@Param("active") boolean active);
+
+    //Accessible via http://127.0.0.1:8080/api/users/search/findByVerified?verified={verified}
+    Iterable<User> findByVerified(@Param("verified") boolean verified);
+
+    //Generate JPA code to save a user, but don't expose an endpoint for it
+    @RestResource(exported=false)
+    User save(User entity);
 }

--- a/src/main/java/org/openlmis/referencedata/web/UserController.java
+++ b/src/main/java/org/openlmis/referencedata/web/UserController.java
@@ -1,0 +1,45 @@
+package org.openlmis.referencedata.web;
+
+import org.openlmis.referencedata.domain.User;
+import org.openlmis.referencedata.repository.UserRepository;
+import org.openlmis.referencedata.util.ServiceSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+    Logger logger = LoggerFactory.getLogger(UserController.class);
+
+    @Autowired
+    private UserRepository userRepository;
+
+    /*
+        Partially due to story OLMIS-726, which involves replacing id fileds with non-sequential UUID values,
+        this POST endpoint will likely change. It exists in its current form largely as a placeholder.
+     */
+    @RequestMapping(path = "/api/users/", method = RequestMethod.POST)
+    public void createUser(@RequestBody User user)
+    {
+        if(user == null || user.getId() == null)
+        {
+            //TODO: Return proper response.
+
+            return;
+        }
+        else
+        {
+            userRepository.save(user);
+
+            //TODO: Return proper response.
+        }
+    }
+
+}


### PR DESCRIPTION
Limit our reference-service’s API primarily to GET operations. It may optionally support object creation, but not modification, for now.

The UserRepository and UserController classes exist as placeholders for how other entities may potentially be exposed once we determine what their endpoints should be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/1)
<!-- Reviewable:end -->
