### PR TITLE
Removed unused response data from endpoints

### DIFF
--- a/src/integration-test/java/org/openlmis/requisition/web/RequisitionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/RequisitionControllerIntegrationTest.java
@@ -41,7 +41,6 @@ import static org.openlmis.requisition.service.PermissionService.REQUISITION_AUT
 import static org.openlmis.requisition.service.PermissionService.REQUISITION_CREATE;
 import static org.openlmis.requisition.service.PermissionService.REQUISITION_DELETE;
 
-import guru.nidi.ramltester.junit.RamlMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -49,6 +48,7 @@ import org.mockito.stubbing.Answer;
 import org.openlmis.requisition.domain.Requisition;
 import org.openlmis.requisition.domain.RequisitionStatus;
 import org.openlmis.requisition.domain.StatusMessage;
+import org.openlmis.requisition.dto.BasicRequisitionDto;
 import org.openlmis.requisition.dto.BasicRequisitionTemplateDto;
 import org.openlmis.requisition.dto.ConvertToOrderDto;
 import org.openlmis.requisition.dto.FacilityDto;
@@ -86,6 +86,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
+
+import guru.nidi.ramltester.junit.RamlMatchers;
+
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -492,7 +495,7 @@ public class RequisitionControllerIntegrationTest extends BaseWebIntegrationTest
     mockValidationSuccess();
 
     // when
-    RequisitionDto result = restAssured.given()
+    BasicRequisitionDto result = restAssured.given()
         .queryParam(ACCESS_TOKEN, getToken())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .pathParam("id", requisitionId)
@@ -500,7 +503,7 @@ public class RequisitionControllerIntegrationTest extends BaseWebIntegrationTest
         .post(SUBMIT_URL)
         .then()
         .statusCode(200)
-        .extract().as(RequisitionDto.class);
+        .extract().as(BasicRequisitionDto.class);
 
     // then
     assertEquals(requisitionId, result.getId());
@@ -982,14 +985,14 @@ public class RequisitionControllerIntegrationTest extends BaseWebIntegrationTest
     mockValidationSuccess();
 
     // when
-    RequisitionDto result = restAssured.given()
+    BasicRequisitionDto result = restAssured.given()
         .queryParam(ACCESS_TOKEN, getToken())
         .pathParam("id", requisitionId)
         .when()
         .post(APPROVE_URL)
         .then()
         .statusCode(200)
-        .extract().as(RequisitionDto.class);
+        .extract().as(BasicRequisitionDto.class);
 
     // then
     assertEquals(requisitionId, result.getId());

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -239,7 +239,7 @@ public class RequisitionController extends BaseController {
   @RequestMapping(value = "/requisitions/{id}/submit", method = RequestMethod.POST)
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public RequisitionDto submitRequisition(@PathVariable("id") UUID requisitionId) {
+  public BasicRequisitionDto submitRequisition(@PathVariable("id") UUID requisitionId) {
     permissionService.canSubmitRequisition(requisitionId);
     Requisition requisition = requisitionRepository.findOne(requisitionId);
     if (requisition == null) {
@@ -268,7 +268,7 @@ public class RequisitionController extends BaseController {
     requisitionStatusProcessor.statusChange(requisition);
     LOGGER.debug("Requisition with id " + requisition.getId() + " submitted");
 
-    return requisitionDtoBuilder.build(requisition);
+    return basicRequisitionDtoBuilder.build(requisition);
   }
 
   /**
@@ -407,12 +407,12 @@ public class RequisitionController extends BaseController {
   @RequestMapping(value = "/requisitions/{id}/skip", method = RequestMethod.PUT)
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public RequisitionDto skipRequisition(@PathVariable("id") UUID requisitionId) {
+  public BasicRequisitionDto skipRequisition(@PathVariable("id") UUID requisitionId) {
     permissionService.canUpdateRequisition(requisitionId);
 
     Requisition requisition = requisitionService.skip(requisitionId);
     requisitionStatusProcessor.statusChange(requisition);
-    return requisitionDtoBuilder.build(requisition);
+    return basicRequisitionDtoBuilder.build(requisition);
   }
 
   /**
@@ -421,14 +421,14 @@ public class RequisitionController extends BaseController {
   @RequestMapping(value = "/requisitions/{id}/reject", method = RequestMethod.PUT)
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public RequisitionDto rejectRequisition(@PathVariable("id") UUID requisitionId) {
+  public BasicRequisitionDto rejectRequisition(@PathVariable("id") UUID requisitionId) {
     permissionService.canApproveRequisition(requisitionId);
     Requisition rejectedRequisition = requisitionService.reject(requisitionId);
     requisitionStatusProcessor.statusChange(rejectedRequisition);
 
     requisitionStatusNotifier.notifyStatusChanged(rejectedRequisition);
 
-    return requisitionDtoBuilder.build(rejectedRequisition);
+    return basicRequisitionDtoBuilder.build(rejectedRequisition);
   }
 
   /**
@@ -437,7 +437,7 @@ public class RequisitionController extends BaseController {
   @RequestMapping(value = "/requisitions/{id}/approve", method = RequestMethod.POST)
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public RequisitionDto approveRequisition(@PathVariable("id") UUID requisitionId) {
+  public BasicRequisitionDto approveRequisition(@PathVariable("id") UUID requisitionId) {
     permissionService.canApproveRequisition(requisitionId);
     Requisition requisition = requisitionRepository.findOne(requisitionId);
     if (requisition == null) {
@@ -480,7 +480,7 @@ public class RequisitionController extends BaseController {
       requisitionRepository.save(requisition);
       requisitionStatusProcessor.statusChange(requisition);
       LOGGER.debug("Requisition with id " + requisitionId + " approved");
-      return requisitionDtoBuilder.build(requisition);
+      return basicRequisitionDtoBuilder.build(requisition);
     } else {
       throw new ValidationMessageException(new Message(
           MessageKeys.ERROR_REQUISITION_MUST_BE_AUTHORIZED_OR_SUBMITTED, requisitionId));
@@ -541,7 +541,7 @@ public class RequisitionController extends BaseController {
   @RequestMapping(value = "/requisitions/{id}/authorize", method = RequestMethod.POST)
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public RequisitionDto authorizeRequisition(@PathVariable("id") UUID requisitionId) {
+  public BasicRequisitionDto authorizeRequisition(@PathVariable("id") UUID requisitionId) {
     permissionService.canAuthorizeRequisition(requisitionId);
 
     if (configurationSettingService.getBoolValue("skipAuthorization")) {
@@ -577,7 +577,7 @@ public class RequisitionController extends BaseController {
     requisitionStatusProcessor.statusChange(requisition);
     LOGGER.debug("Requisition: " + requisitionId + " authorized.");
 
-    return requisitionDtoBuilder.build(requisition);
+    return basicRequisitionDtoBuilder.build(requisition);
   }
 
   /**

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -36,6 +36,12 @@ schemas:
            }
       }
 
+  - orderableDtoArray: |
+      {
+          "type": "array",
+          "items": { "type": "object", "$ref": "#/schemas/orderableDto" }
+      }
+
   - processingPeriodDto: !include schemas/processingPeriodDto.json
 
   - processingScheduleDto: |
@@ -512,6 +518,19 @@ resourceTypes:
                       body:
                         application/json:
                           schema: statusMessageArray
+                  403:
+                      body:
+                        application/json:
+                          schema: localizedMessage
+      /{id}/availableNonFullSupply:
+          get:
+              is: [ secured ]
+              description: Get available non Full supply products associated with a requisition.
+              responses:
+                  200:
+                      body:
+                        application/json:
+                          schema: orderableDtoArray
                   403:
                       body:
                         application/json:

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -36,12 +36,6 @@ schemas:
            }
       }
 
-  - orderableDtoArray: |
-      {
-          "type": "array",
-          "items": { "type": "object", "$ref": "#/schemas/orderableDto" }
-      }
-
   - processingPeriodDto: !include schemas/processingPeriodDto.json
 
   - processingScheduleDto: |
@@ -518,19 +512,6 @@ resourceTypes:
                       body:
                         application/json:
                           schema: statusMessageArray
-                  403:
-                      body:
-                        application/json:
-                          schema: localizedMessage
-      /{id}/availableNonFullSupply:
-          get:
-              is: [ secured ]
-              description: Get available non Full supply products associated with a requisition.
-              responses:
-                  200:
-                      body:
-                        application/json:
-                          schema: orderableDtoArray
                   403:
                       body:
                         application/json:

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -21,6 +21,8 @@ schemas:
 
   - geographicZoneDto: !include schemas/geographicZoneDto.json
 
+  - basicRequisitionDto: !include schemas/basicRequisitionDto.json
+
   - basicRequisitionDtoPage: !include schemas/basicRequisitionDtoPage.json
 
   - orderableDto: |
@@ -406,6 +408,7 @@ resourceTypes:
                   "200":
                       body:
                         application/json:
+                            schema: basicRequisitionDto
                   "400":
                       body:
                         application/json:
@@ -432,6 +435,7 @@ resourceTypes:
                   "200":
                       body:
                         application/json:
+                            schema: basicRequisitionDto
                   "400":
                       body:
                         application/json:
@@ -452,6 +456,7 @@ resourceTypes:
                   "200":
                       body:
                         application/json:
+                            schema: basicRequisitionDto
                   "400":
                       body:
                         application/json:
@@ -473,6 +478,7 @@ resourceTypes:
                   "200":
                       body:
                         application/json:
+                            schema: basicRequisitionDto
                   "400":
                       body:
                         application/json:
@@ -582,6 +588,7 @@ resourceTypes:
                   "200":
                       body:
                         application/json:
+                            schema: basicRequisitionDto
                   "400":
                       body:
                         application/json:

--- a/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
@@ -123,6 +123,9 @@ public class RequisitionControllerTest {
   private PermissionService permissionService;
 
   @Mock
+  private BasicRequisitionDtoBuilder basicRequisitionDtoBuilder;
+
+  @Mock
   private RequisitionDtoBuilder requisitionDtoBuilder;
 
   @Mock


### PR DESCRIPTION
The following endpoints return full requsition dto object but we think that those endpoints should only return basic information about a requsition and if a user would like to retrieve all data he/she should use **GET /api/requisitions/{id}**. This should speed up related processes because the server will not waste time to construct the full object.

- PUT /api/requisitions/{id}/skip
- PUT /api/requisitions/{id}/reject
- POST /api/requisitions/{id}/submit
- POST /api/requisitions/{id}/authorize
- POST /api/requisitions/{id}/approve

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/25)
<!-- Reviewable:end -->
