### PR TITLE
MW-310: Improve requisition search performance

### DIFF
--- a/src/main/java/org/openlmis/requisition/domain/Requisition.java
+++ b/src/main/java/org/openlmis/requisition/domain/Requisition.java
@@ -95,7 +95,7 @@ public class Requisition extends BaseTimestampedEntity {
   @OneToMany(
       mappedBy = "requisition",
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.REMOVE},
-      fetch = FetchType.EAGER,
+      fetch = FetchType.LAZY,
       orphanRemoval = true)
   @Fetch(FetchMode.SELECT)
   @DiffIgnore


### PR DESCRIPTION
Lazy-load line items - we don't use them when searching requisitions
With a database that has 140k requisitions the time it takes to search them was reduced from 1300 to around 10 seconds. The requisition workflow seem to work fine still since we are using @Transactional on controllers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/29)
<!-- Reviewable:end -->
