### PR TITLE
Improve performance of view right checking for multiple requisitions

### DIFF
--- a/src/main/java/org/openlmis/requisition/service/PermissionService.java
+++ b/src/main/java/org/openlmis/requisition/service/PermissionService.java
@@ -165,6 +165,15 @@ public class PermissionService {
   }
 
   /**
+   * Checks if current user has permission to view a requisition.
+   * @return true if user has got the necessary rights to view given requisition; false otherwise
+   */
+  public boolean canViewRequisition(Requisition requisition) {
+    return hasPermission(REQUISITION_VIEW, requisition.getProgramId(),
+        requisition.getFacilityId(), null);
+  }
+
+  /**
    * Checks if current user has permission to convert requisition to order.
    *
    * @param list of ConvertToOrderDtos containing chosen requisitionId and supplyingDepotId.

--- a/src/main/java/org/openlmis/requisition/service/RequisitionSecurityService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionSecurityService.java
@@ -1,0 +1,81 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.service;
+
+import org.openlmis.requisition.domain.Requisition;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class RequisitionSecurityService {
+
+  @Autowired
+  private PermissionService permissionService;
+
+  /**
+   * Filters requisitions based on user permissions. It strives to make as little calls to the
+   * reference data service as possible.
+   *
+   * @param allRequisitions input list containing any requisitions
+   * @return filtered input list of requisitions, containing only those that the user has access to
+   */
+  public List<Requisition> filterInaccessibleRequisitions(List<Requisition> allRequisitions) {
+
+    Map<RightsFor, Boolean> verified = new HashMap<>();
+    List<Requisition> filteredList = new ArrayList<>();
+
+    for (Requisition requisition : allRequisitions) {
+      Boolean accessible = getCachedRight(verified, requisition);
+
+      if (accessible == null) {
+        accessible = permissionService.canViewRequisition(requisition);
+        addCachedRight(verified, requisition, accessible);
+      }
+
+      if (accessible) {
+        filteredList.add(requisition);
+      }
+    }
+
+    return filteredList;
+  }
+
+  private Boolean getCachedRight(Map<RightsFor, Boolean> verified, Requisition requisition) {
+    return verified.get(new RightsFor(requisition.getProgramId(), requisition.getFacilityId()));
+  }
+
+  private void addCachedRight(Map<RightsFor, Boolean> verified,
+                              Requisition requisition, Boolean accessible) {
+    verified.put(
+        new RightsFor(requisition.getProgramId(), requisition.getFacilityId()), accessible);
+  }
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  private class RightsFor {
+    private UUID program;
+    private UUID facility;
+  }
+}

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -48,6 +48,7 @@ import org.openlmis.requisition.repository.RequisitionRepository;
 import org.openlmis.requisition.repository.StatusMessageRepository;
 import org.openlmis.requisition.service.PeriodService;
 import org.openlmis.requisition.service.PermissionService;
+import org.openlmis.requisition.service.RequisitionSecurityService;
 import org.openlmis.requisition.service.RequisitionService;
 import org.openlmis.requisition.service.RequisitionStatusNotifier;
 import org.openlmis.requisition.service.RequisitionStatusProcessor;
@@ -134,6 +135,9 @@ public class RequisitionController extends BaseController {
 
   @Autowired
   private PermissionService permissionService;
+
+  @Autowired
+  private RequisitionSecurityService requisitionSecurityService;
 
   @Autowired
   private RequisitionDtoBuilder requisitionDtoBuilder;
@@ -392,14 +396,8 @@ public class RequisitionController extends BaseController {
         initiatedDateFrom, initiatedDateTo, processingPeriod, supervisoryNode, requisitionStatuses,
         emergency);
 
-    List<Requisition> filteredList = requisitions.stream().filter(req -> {
-      try {
-        permissionService.canViewRequisition(req.getId());
-      } catch (PermissionMessageException ex) {
-        return false;
-      }
-      return true;
-    }).collect(Collectors.toList());
+    List<Requisition> filteredList =
+        requisitionSecurityService.filterInaccessibleRequisitions(requisitions);
 
     List<BasicRequisitionDto> dtoList = basicRequisitionDtoBuilder.build(filteredList);
     return Pagination.getPage(dtoList, pageable);
@@ -524,14 +522,8 @@ public class RequisitionController extends BaseController {
     List<Requisition> submittedRequisitions = requisitionService.searchRequisitions(
         EnumSet.of(RequisitionStatus.SUBMITTED));
 
-    List<Requisition> filteredList = submittedRequisitions.stream().filter(req -> {
-      try {
-        permissionService.canViewRequisition(req.getId());
-      } catch (PermissionMessageException ex) {
-        return false;
-      }
-      return true;
-    }).collect(Collectors.toList());
+    List<Requisition> filteredList =
+        requisitionSecurityService.filterInaccessibleRequisitions(submittedRequisitions);
 
     List<RequisitionDto> dtoList = requisitionDtoBuilder.build(filteredList);
 

--- a/src/test/java/org/openlmis/requisition/service/RequisitionSecurityServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionSecurityServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.openlmis.requisition.domain.Requisition;
+
+import java.util.List;
+import java.util.UUID;
+
+public class RequisitionSecurityServiceTest {
+
+  @Mock
+  private PermissionService permissionService;
+
+  @InjectMocks
+  private RequisitionSecurityService requisitionSecurityService = new RequisitionSecurityService();
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void shouldUseCachedRightIfOneExists() {
+    final UUID facility = UUID.randomUUID();
+    final UUID program = UUID.randomUUID();
+    final Requisition requisition = mockRequisition(facility, program);
+
+    List<Requisition> allRequisitions = Lists.newArrayList(requisition, requisition, requisition);
+
+    requisitionSecurityService.filterInaccessibleRequisitions(allRequisitions);
+
+    // The permission service should be called only one time, despite having 3 requisitions, due
+    // to caching
+    verify(permissionService, times(1)).canViewRequisition(any(Requisition.class));
+  }
+
+  @Test
+  public void shouldNotUseCachedRightIfAllCallsAreDifferent() {
+    final Requisition requisition = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+    final Requisition requisition2 = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+    final Requisition requisition3 = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+
+    List<Requisition> allRequisitions = Lists.newArrayList(requisition, requisition2, requisition3);
+
+    requisitionSecurityService.filterInaccessibleRequisitions(allRequisitions);
+
+    // The permission service should be called one time for each requisition (no cache hits)
+    verify(permissionService, times(3)).canViewRequisition(any(Requisition.class));
+  }
+
+  @Test
+  public void shouldProperlyFilterAccessibleRequisitions() {
+    final Requisition requisition = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+    final Requisition requisition2 = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+    final Requisition requisition3 = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+    final Requisition requisition4 = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
+
+    when(permissionService.canViewRequisition(any(Requisition.class)))
+        .thenReturn(true, false, false, true);
+
+    List<Requisition> allRequisitions = Lists.newArrayList(requisition, requisition2,
+        requisition3, requisition4);
+    List<Requisition> result = requisitionSecurityService
+        .filterInaccessibleRequisitions(allRequisitions);
+
+    assertEquals(2, result.size());
+    assertEquals(requisition, result.get(0));
+    assertEquals(requisition4, result.get(1));
+  }
+
+  private Requisition mockRequisition(UUID programId, UUID facilityId) {
+    Requisition requisition = new Requisition();
+    requisition.setProgramId(programId);
+    requisition.setFacilityId(facilityId);
+    return requisition;
+  }
+}


### PR DESCRIPTION
For places where we need to verify rights for multiple requisitions
the caching mechanism has been introduced. Calls to reference data
service are made only for facility/program combo that haven't been
checked already for the given batch of requisitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/30)
<!-- Reviewable:end -->
