### PR TITLE
Improve checking last requisition status query

### DIFF
--- a/src/main/java/org/openlmis/requisition/repository/custom/RequisitionRepositoryCustom.java
+++ b/src/main/java/org/openlmis/requisition/repository/custom/RequisitionRepositoryCustom.java
@@ -41,5 +41,5 @@ public interface RequisitionRepositoryCustom {
   List<Requisition> searchApprovedRequisitions(String filterBy,
                                                List<UUID> desiredUuids);
 
-  Requisition getLastRegularRequisition(UUID facility, UUID program);
+  RequisitionStatus getLastRegularRequisitionStatus(UUID facility, UUID program);
 }

--- a/src/main/java/org/openlmis/requisition/repository/custom/impl/RequisitionRepositoryImpl.java
+++ b/src/main/java/org/openlmis/requisition/repository/custom/impl/RequisitionRepositoryImpl.java
@@ -188,14 +188,15 @@ public class RequisitionRepositoryImpl implements RequisitionRepositoryCustom {
    * @throws IllegalArgumentException if any of arguments is {@code null}.
    */
   @Override
-  public Requisition getLastRegularRequisition(UUID facility, UUID program) {
+  public RequisitionStatus getLastRegularRequisitionStatus(UUID facility, UUID program) {
     if (null == facility || null == program) {
       throw new IllegalArgumentException("facility and program must be provided");
     }
 
     CriteriaBuilder builder = entityManager.getCriteriaBuilder();
 
-    CriteriaQuery<Requisition> query = builder.createQuery(Requisition.class);
+    CriteriaQuery<RequisitionStatus> query = builder.createQuery(RequisitionStatus.class);
+
 
     Root<Requisition> root = query.from(Requisition.class);
 
@@ -204,10 +205,11 @@ public class RequisitionRepositoryImpl implements RequisitionRepositoryCustom {
     predicate = builder.and(predicate, builder.equal(root.get(FACILITY_ID), facility));
     predicate = builder.and(predicate, builder.equal(root.get(PROGRAM_ID), program));
 
+    query.select(root.get("status"));
     query.where(predicate);
     query.orderBy(builder.desc(root.get(CREATED_DATE)));
 
-    List<Requisition> requisitionList = entityManager.createQuery(query)
+    List<RequisitionStatus> requisitionList = entityManager.createQuery(query)
                                         .setMaxResults(1).getResultList();
     return (requisitionList == null || requisitionList.isEmpty()) ? null : requisitionList.get(0);
   }

--- a/src/main/java/org/openlmis/requisition/service/PeriodService.java
+++ b/src/main/java/org/openlmis/requisition/service/PeriodService.java
@@ -234,11 +234,11 @@ public class PeriodService {
    */
   private ProcessingPeriodDto findTheOldestPeriod(UUID programId, UUID facilityId) {
 
-    Requisition lastRequisition = requisitionRepository.getLastRegularRequisition(
+    RequisitionStatus lastStatus = requisitionRepository.getLastRegularRequisitionStatus(
         facilityId, programId
     );
 
-    if (null != lastRequisition && lastRequisition.isPreAuthorize()) {
+    if (null != lastStatus && lastStatus.isPreAuthorize()) {
       throw new ValidationMessageException(new Message(ERROR_FINISH_PROVIOUS_REQUISITION));
     }
 

--- a/src/test/java/org/openlmis/requisition/service/PeriodServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/PeriodServiceTest.java
@@ -358,9 +358,8 @@ public class PeriodServiceTest {
   @Test(expected = ValidationMessageException.class)
   public void shouldThrowExceptionWhenPreviousReqHasInitiatedStatus() {
 
-    Requisition requisition = getRequisition(INITIATED);
-    when(requisitionRepository.getLastRegularRequisition(facilityId, programId))
-        .thenReturn(requisition);
+    when(requisitionRepository.getLastRegularRequisitionStatus(facilityId, programId))
+        .thenReturn(INITIATED);
 
     periodService.findPeriod(programId, facilityId, null, false);
   }
@@ -368,9 +367,8 @@ public class PeriodServiceTest {
   @Test(expected = ValidationMessageException.class)
   public void shouldThrowExceptionWhenPreviousReqHasSubmittedStatus() {
 
-    Requisition requisition = getRequisition(SUBMITTED);
-    when(requisitionRepository.getLastRegularRequisition(facilityId, programId))
-        .thenReturn(requisition);
+    when(requisitionRepository.getLastRegularRequisitionStatus(facilityId, programId))
+        .thenReturn(SUBMITTED);
 
     periodService.findPeriod(programId, facilityId, null, false);
   }
@@ -453,8 +451,8 @@ public class PeriodServiceTest {
   }
 
   private void setMockForFindPeriod(Requisition requisition) {
-    when(requisitionRepository.getLastRegularRequisition(facilityId, programId))
-        .thenReturn(requisition);
+    when(requisitionRepository.getLastRegularRequisitionStatus(facilityId, programId))
+        .thenReturn(requisition.getStatus());
     List<ProcessingPeriodDto> periods = new ArrayList<>();
     periods.add(period1);
     periods.add(period2);


### PR DESCRIPTION
The application logic that was supposed to check the status
of a last requisition was retrieving a whole requisition object from
the database. This meant that the query needed to include all the line
items for requisitions, status changes and other things that weren't needed.
I've adjusted the query to just retrieve the status what should make the
execution time faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/31)
<!-- Reviewable:end -->
