### PR TITLE
Add ability to sort by several fields in requisitionsForConvert endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Contract breaking changes:
 New functionality added in a backwards-compatible manner:
 
 * [OLMIS-2709](https://openlmis.atlassian.net/browse/OLMIS-2709): Changed ReferenceData facility service search endpoint to use smaller dto.
+* The /requisitions/requisitionsForConvert endpoint accepts several sortBy parameters. Data returned by the endpoint will be sorted by those parameters in order of occurrence. By defaults data will be sorted by emergency flag and program name.
 
 Bug fixes added in a backwards-compatible manner:
 * [OLMIS-2788](https://openlmis.atlassian.net/browse/OLMIS-2788): Fixed print requisition.

--- a/src/main/java/org/openlmis/requisition/service/RequisitionService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionService.java
@@ -508,7 +508,7 @@ public class RequisitionService {
   public Page<RequisitionWithSupplyingDepotsDto>
       searchApprovedRequisitionsWithSortAndFilterAndPaging(String filterValue,
                                                            String filterBy,
-                                                           String sortBy,
+                                                           List<String> sortBy,
                                                            Boolean descending,
                                                            Pageable pageable,
                                                            Collection<UUID> userManagedFacilities) {

--- a/src/main/java/org/openlmis/requisition/service/RequisitionService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionService.java
@@ -36,11 +36,11 @@ import org.openlmis.requisition.domain.RequisitionStatus;
 import org.openlmis.requisition.domain.RequisitionTemplate;
 import org.openlmis.requisition.domain.StatusMessage;
 import org.openlmis.requisition.dto.ApprovedProductDto;
-import org.openlmis.requisition.dto.MinimalFacilityDto;
 import org.openlmis.requisition.dto.BasicRequisitionDto;
 import org.openlmis.requisition.dto.ConvertToOrderDto;
 import org.openlmis.requisition.dto.DetailedRoleAssignmentDto;
 import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.MinimalFacilityDto;
 import org.openlmis.requisition.dto.OrderDto;
 import org.openlmis.requisition.dto.OrderableDto;
 import org.openlmis.requisition.dto.ProcessingPeriodDto;
@@ -67,9 +67,9 @@ import org.openlmis.requisition.web.BasicRequisitionDtoBuilder;
 import org.openlmis.requisition.web.OrderDtoBuilder;
 import org.openlmis.requisition.web.PermissionMessageException;
 import org.openlmis.utils.AuthenticationHelper;
+import org.openlmis.utils.BasicRequisitionDtoComparator;
 import org.openlmis.utils.Message;
 import org.openlmis.utils.Pagination;
-import org.openlmis.utils.BasicRequisitionDtoComparator;
 import org.openlmis.utils.RightName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +82,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -498,8 +497,6 @@ public class RequisitionService {
    * @param filterValue Value to be used to filter.
    * @param filterBy    Field used to filter: "programName", "facilityCode", "facilityName" or
    *                    "all".
-   * @param sortBy      Field used to sort: "programName", "facilityCode" or "facilityName".
-   * @param descending  Descending direction for sort.
    * @param pageable    Pageable object that allows to optionally add "page" (page number)
    *                     and "size" (page size) query parameters.
    * @param userManagedFacilities List of UUIDs of facilities that are managed by logged in user.
@@ -508,8 +505,6 @@ public class RequisitionService {
   public Page<RequisitionWithSupplyingDepotsDto>
       searchApprovedRequisitionsWithSortAndFilterAndPaging(String filterValue,
                                                            String filterBy,
-                                                           List<String> sortBy,
-                                                           Boolean descending,
                                                            Pageable pageable,
                                                            Collection<UUID> userManagedFacilities) {
     List<UUID> desiredUuids = findDesiredUuids(filterValue, filterBy);
@@ -518,10 +513,7 @@ public class RequisitionService {
     List<BasicRequisitionDto> requisitionDtosList =
         basicRequisitionDtoBuilder.build(requisitionsList);
 
-    requisitionDtosList.sort(new BasicRequisitionDtoComparator(sortBy));
-    if (descending) {
-      Collections.reverse(requisitionDtosList);
-    }
+    requisitionDtosList.sort(new BasicRequisitionDtoComparator(pageable));
 
     List<RequisitionWithSupplyingDepotsDto> responseList = new ArrayList<>();
     for (BasicRequisitionDto requisition : requisitionDtosList) {

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -598,7 +598,7 @@ public class RequisitionController extends BaseController {
   public Page<RequisitionWithSupplyingDepotsDto> listForConvertToOrder(
       @RequestParam(required = false) String filterValue,
       @RequestParam(required = false) String filterBy,
-      @RequestParam(required = false, defaultValue = "programName") String sortBy,
+      @RequestParam(required = false) List<String> sortBy,
       @RequestParam(required = false, defaultValue = "true") boolean descending,
       Pageable pageable) {
     UserDto user = authenticationHelper.getCurrentUser();

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -586,10 +586,6 @@ public class RequisitionController extends BaseController {
    * @param filterValue Value to be used to filter.
    * @param filterBy    Field used to filter: "programName", "facilityCode", "facilityName" or
    *                    "all".
-   * @param sortBy      Fields used to sort: "emergency", "programName", "facilityCode" and/or
-   *                    "facilityName". If this parameter is empty/null, data will be sorted by
-   *                    emergency flag and program name.
-   * @param descending  Descending direction for sort.
    * @param pageable     Pageable object that allows client to optionally add "page" (page number)
    *                     and "size" (page size) query parameters to the request.
    * @return Page of approved requisitions.
@@ -600,8 +596,6 @@ public class RequisitionController extends BaseController {
   public Page<RequisitionWithSupplyingDepotsDto> listForConvertToOrder(
       @RequestParam(required = false) String filterValue,
       @RequestParam(required = false) String filterBy,
-      @RequestParam(required = false) List<String> sortBy,
-      @RequestParam(required = false, defaultValue = "true") boolean descending,
       Pageable pageable) {
     UserDto user = authenticationHelper.getCurrentUser();
     RightDto right = authenticationHelper.getRight(RightName.ORDERS_EDIT);
@@ -611,7 +605,7 @@ public class RequisitionController extends BaseController {
         .stream().map(FacilityDto::getId).collect(Collectors.toList());
 
     return requisitionService.searchApprovedRequisitionsWithSortAndFilterAndPaging(
-            filterValue, filterBy, sortBy, descending, pageable, userManagedFacilities);
+            filterValue, filterBy, pageable, userManagedFacilities);
   }
 
   /**

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -586,7 +586,9 @@ public class RequisitionController extends BaseController {
    * @param filterValue Value to be used to filter.
    * @param filterBy    Field used to filter: "programName", "facilityCode", "facilityName" or
    *                    "all".
-   * @param sortBy      Field used to sort: "programName", "facilityCode" or "facilityName".
+   * @param sortBy      Fields used to sort: "emergency", "programName", "facilityCode" and/or
+   *                    "facilityName". If this parameter is empty/null, data will be sorted by
+   *                    emergency flag and program name.
    * @param descending  Descending direction for sort.
    * @param pageable     Pageable object that allows client to optionally add "page" (page number)
    *                     and "size" (page size) query parameters to the request.

--- a/src/main/java/org/openlmis/utils/BasicRequisitionDtoComparator.java
+++ b/src/main/java/org/openlmis/utils/BasicRequisitionDtoComparator.java
@@ -17,6 +17,7 @@ package org.openlmis.utils;
 
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_COLUMN_iS_NOT_VALID_FOR_SORTING;
 import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -55,7 +56,7 @@ public class BasicRequisitionDtoComparator implements Comparator<BasicRequisitio
 
     if (null == sort) {
       sort = new Sort(
-          new Sort.Order(ASC, "emergency"), new Sort.Order(ASC, "programName")
+          new Sort.Order(DESC, "emergency"), new Sort.Order(ASC, "programName")
       );
     }
 

--- a/src/main/java/org/openlmis/utils/BasicRequisitionDtoComparator.java
+++ b/src/main/java/org/openlmis/utils/BasicRequisitionDtoComparator.java
@@ -16,37 +16,83 @@
 package org.openlmis.utils;
 
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_COLUMN_iS_NOT_VALID_FOR_SORTING;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import org.apache.commons.beanutils.BeanComparator;
+import org.apache.commons.collections.comparators.ComparatorChain;
 import org.openlmis.requisition.dto.BasicRequisitionDto;
 import org.openlmis.requisition.exception.ValidationMessageException;
 
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 
-@NoArgsConstructor
-@AllArgsConstructor
 public class BasicRequisitionDtoComparator implements Comparator<BasicRequisitionDto> {
+  private static final Map<String, FieldComparator> AVAILABLE_COMPARATORS;
 
-  private String compareCondition;
+  static {
+    AVAILABLE_COMPARATORS = Maps.newHashMap();
+    AVAILABLE_COMPARATORS.put("emergency", new FieldComparator("emergency", false));
+    AVAILABLE_COMPARATORS.put("programName",new FieldComparator("program.name"));
+    AVAILABLE_COMPARATORS.put("facilityCode", new FieldComparator("facility.code"));
+    AVAILABLE_COMPARATORS.put("facilityName", new FieldComparator("facility.name"));
+  }
+
+  private List<String> compareConditions;
+
+  /**
+   * Creates new instance with a single compare condition.
+   */
+  public BasicRequisitionDtoComparator(String compareCondition) {
+    this(Collections.singletonList(compareCondition));
+  }
+
+  /**
+   * Creates new instance with the passed compare conditions.
+   */
+  public BasicRequisitionDtoComparator(List<String> compareConditions) {
+    this.compareConditions = isEmpty(compareConditions)
+        ? Lists.newArrayList("emergency", "programName")
+        : compareConditions;
+  }
 
   @Override
   public int compare(BasicRequisitionDto o1, BasicRequisitionDto o2) {
-    switch (compareCondition) {
-      case "programName": {
-        return o1.getProgram().getName().compareTo(o2.getProgram().getName());
+    ComparatorChain chain = new ComparatorChain();
+
+    for (int i = 0, size = compareConditions.size(); i < size; ++i) {
+      String compareCondition = compareConditions.get(i);
+      FieldComparator comparator = AVAILABLE_COMPARATORS.get(compareCondition);
+
+      if (null == comparator) {
+        throw new ValidationMessageException(
+            new Message(ERROR_COLUMN_iS_NOT_VALID_FOR_SORTING, compareCondition)
+        );
       }
-      case "facilityCode": {
-        return o1.getFacility().getCode().compareTo(o2.getFacility().getCode());
-      }
-      case "facilityName": {
-        return o1.getFacility().getName().compareTo(o2.getFacility().getName());
-      }
-      default: {
-        throw new ValidationMessageException(new Message(ERROR_COLUMN_iS_NOT_VALID_FOR_SORTING,
-            compareCondition));
-      }
+
+      chain.addComparator(comparator,  comparator.reverse);
     }
+
+    return chain.compare(o1, o2);
   }
+
+
+  private static final class FieldComparator extends BeanComparator {
+    private boolean reverse;
+
+    FieldComparator(String property) {
+      this(property, true);
+    }
+
+    FieldComparator(String property, boolean reverse) {
+      super(property);
+      this.reverse = reverse;
+    }
+
+  }
+
 }

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -508,7 +508,7 @@ resourceTypes:
                   filterBy:
                       displayName: filterBy
                       description: This parameter contains field which we are going to filter by.
-                        There is four possibilities - facilityCode, facilityName, programName
+                        There are four possibilities - facilityCode, facilityName, programName
                         and all
                       type: string
                       required: false
@@ -516,7 +516,8 @@ resourceTypes:
                   sortBy:
                       displayName: sortBy
                       description: This parameter contains field which we are going to sort by.
-                        There is four possibilities - emergency, facilityCode, facilityName and programName
+                        There are four possibilities - emergency, facilityCode, facilityName and programName.
+                        If this parameter is not set, data will be sorted by emergency flag and program name.
                       type: string
                       required: false
                       repeat: true

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -516,7 +516,7 @@ resourceTypes:
                   sortBy:
                       displayName: sortBy
                       description: This parameter contains field which we are going to sort by.
-                        There is three possibilities -  facilityCode, facilityName and programName
+                        There is four possibilities - emergency, facilityCode, facilityName and programName
                       type: string
                       required: false
                       repeat: true

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -519,7 +519,7 @@ resourceTypes:
                         There is three possibilities -  facilityCode, facilityName and programName
                       type: string
                       required: false
-                      repeat: false
+                      repeat: true
                   descending:
                       displayName: descending
                       description: This parameter contains sorting order. Default it is descending,

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -113,6 +113,14 @@ traits:
                   type: integer
                   required: false
                   repeat: false
+    - sorted:
+          queryParameters:
+              sort:
+                  description: Sorting criteria in the format "property(,asc|desc)". Default sort order is ascending. Multiple sort criteria are supported.
+                  type: string
+                  required: false
+                  repeat: true
+
 resourceTypes:
     - collection:
         get:
@@ -496,7 +504,7 @@ resourceTypes:
                   "500":
       /requisitionsForConvert:
           get:
-              is: [ secured, paginated ]
+              is: [ secured, paginated, sorted ]
               description: Get requisitions to approve for right supervisor.
               queryParameters:
                   filterValue:
@@ -511,21 +519,6 @@ resourceTypes:
                         There are four possibilities - facilityCode, facilityName, programName
                         and all
                       type: string
-                      required: false
-                      repeat: false
-                  sortBy:
-                      displayName: sortBy
-                      description: This parameter contains field which we are going to sort by.
-                        There are four possibilities - emergency, facilityCode, facilityName and programName.
-                        If this parameter is not set, data will be sorted by emergency flag and program name.
-                      type: string
-                      required: false
-                      repeat: true
-                  descending:
-                      displayName: descending
-                      description: This parameter contains sorting order. Default it is descending,
-                        but if user want to have ascending order there should be false.
-                      type: boolean
                       required: false
                       repeat: false
               responses:

--- a/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
@@ -100,6 +100,7 @@ import org.openlmis.utils.BasicRequisitionDtoComparator;
 import org.openlmis.utils.RightName;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -895,12 +896,14 @@ public class RequisitionServiceTest {
     int pageSize = 3;
     int pageNumber = 0;
     Pageable pageable = mock(Pageable.class);
+    Sort sort = new Sort(Sort.Direction.DESC, filterAndSortBy);
+
+    when(pageable.getSort()).thenReturn(sort);
 
     setupStubsForTestApprovedRequisition(requisitionDtos, filterAndSortBy, filterAndSortBy,
         supplyingDepots, pageable, pageSize, pageNumber);
 
-    requisitionDtos.sort(new BasicRequisitionDtoComparator(filterAndSortBy));
-    Collections.reverse(requisitionDtos);
+    requisitionDtos.sort(new BasicRequisitionDtoComparator(pageable));
     
     List<BasicRequisitionDto> requisitionDtosSubList =
         requisitionDtos.subList(pageNumber * pageSize, pageNumber * pageSize + pageSize);
@@ -917,8 +920,7 @@ public class RequisitionServiceTest {
     //when
     Page<RequisitionWithSupplyingDepotsDto> requisitionDtosRetrieved =
         requisitionService.searchApprovedRequisitionsWithSortAndFilterAndPaging(null,
-            filterAndSortBy, Collections.singletonList(filterAndSortBy), true, pageable,
-            userManagedFacilities);
+            filterAndSortBy, pageable, userManagedFacilities);
 
     List<RequisitionWithSupplyingDepotsDto> requisitionDtosRetrievedList =
         requisitionDtosRetrieved.getContent();

--- a/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
@@ -917,7 +917,8 @@ public class RequisitionServiceTest {
     //when
     Page<RequisitionWithSupplyingDepotsDto> requisitionDtosRetrieved =
         requisitionService.searchApprovedRequisitionsWithSortAndFilterAndPaging(null,
-            filterAndSortBy, filterAndSortBy, true, pageable, userManagedFacilities);
+            filterAndSortBy, Collections.singletonList(filterAndSortBy), true, pageable,
+            userManagedFacilities);
 
     List<RequisitionWithSupplyingDepotsDto> requisitionDtosRetrievedList =
         requisitionDtosRetrieved.getContent();

--- a/src/test/java/org/openlmis/utils/BasicRequisitionDtoComparatorTest.java
+++ b/src/test/java/org/openlmis/utils/BasicRequisitionDtoComparatorTest.java
@@ -1,0 +1,93 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.utils;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.dto.BasicRequisitionDto;
+import org.openlmis.requisition.dto.ProgramDto;
+import org.openlmis.requisition.exception.ValidationMessageException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BasicRequisitionDtoComparatorTest {
+
+  @Mock
+  private ProgramDto program1;
+
+  @Mock
+  private ProgramDto program2;
+
+  @Mock
+  private BasicRequisitionDto requisition1;
+
+  @Mock
+  private BasicRequisitionDto requisition2;
+
+  @Before
+  public void setUp() throws Exception {
+    when(requisition1.getProgram()).thenReturn(program1);
+    when(requisition2.getProgram()).thenReturn(program2);
+  }
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowExceptionIfComparatorDoesNotExist() throws Exception {
+    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator("abc");
+    comparator.compare(requisition1, requisition2);
+  }
+
+  @Test
+  public void shouldCompareBySingleField() throws Exception {
+    when(requisition1.getEmergency()).thenReturn(true);
+    when(requisition2.getEmergency()).thenReturn(false);
+
+    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator("emergency");
+
+    assertThat(comparator.compare(requisition1, requisition2), is(greaterThan(0)));
+    assertThat(comparator.compare(requisition2, requisition1), is(lessThan(0)));
+    assertThat(comparator.compare(requisition1, requisition1), is(equalTo(0)));
+    assertThat(comparator.compare(requisition2, requisition2), is(equalTo(0)));
+  }
+
+  @Test
+  public void shouldCompareBySeveralFields() throws Exception {
+    when(requisition1.getEmergency()).thenReturn(true);
+    when(requisition2.getEmergency()).thenReturn(true);
+
+    when(program1.getName()).thenReturn("A");
+    when(program2.getName()).thenReturn("D");
+
+
+    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator(
+        Lists.newArrayList("emergency", "programName")
+    );
+
+    assertThat(comparator.compare(requisition1, requisition2), is(greaterThan(0)));
+    assertThat(comparator.compare(requisition2, requisition1), is(lessThan(0)));
+    assertThat(comparator.compare(requisition1, requisition1), is(equalTo(0)));
+    assertThat(comparator.compare(requisition2, requisition2), is(equalTo(0)));
+  }
+}

--- a/src/test/java/org/openlmis/utils/BasicRequisitionDtoComparatorTest.java
+++ b/src/test/java/org/openlmis/utils/BasicRequisitionDtoComparatorTest.java
@@ -21,8 +21,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
-import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,9 +32,14 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.openlmis.requisition.dto.BasicRequisitionDto;
 import org.openlmis.requisition.dto.ProgramDto;
 import org.openlmis.requisition.exception.ValidationMessageException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BasicRequisitionDtoComparatorTest {
+
+  @Mock
+  private Pageable pageable;
 
   @Mock
   private ProgramDto program1;
@@ -55,7 +61,9 @@ public class BasicRequisitionDtoComparatorTest {
 
   @Test(expected = ValidationMessageException.class)
   public void shouldThrowExceptionIfComparatorDoesNotExist() throws Exception {
-    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator("abc");
+    when(pageable.getSort()).thenReturn(new Sort("abc"));
+
+    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator(pageable);
     comparator.compare(requisition1, requisition2);
   }
 
@@ -64,7 +72,9 @@ public class BasicRequisitionDtoComparatorTest {
     when(requisition1.getEmergency()).thenReturn(true);
     when(requisition2.getEmergency()).thenReturn(false);
 
-    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator("emergency");
+    when(pageable.getSort()).thenReturn(new Sort(new Sort.Order(DESC, "emergency")));
+
+    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator(pageable);
 
     assertThat(comparator.compare(requisition1, requisition2), is(greaterThan(0)));
     assertThat(comparator.compare(requisition2, requisition1), is(lessThan(0)));
@@ -80,10 +90,12 @@ public class BasicRequisitionDtoComparatorTest {
     when(program1.getName()).thenReturn("A");
     when(program2.getName()).thenReturn("D");
 
-
-    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator(
-        Lists.newArrayList("emergency", "programName")
+    when(pageable.getSort()).thenReturn(
+        new Sort(new Sort.Order(DESC, "emergency"), new Sort.Order(ASC, "programName"))
     );
+
+
+    BasicRequisitionDtoComparator comparator = new BasicRequisitionDtoComparator(pageable);
 
     assertThat(comparator.compare(requisition1, requisition2), is(greaterThan(0)));
     assertThat(comparator.compare(requisition2, requisition1), is(lessThan(0)));


### PR DESCRIPTION
The _/requisitions/requisitionsForConvert_ endpoint accepts several **sortBy** parameters. Data returned by the endpoint will be sorted by those parameters in order of occurrence. By defaults data will be sorted by _emergency_ flag and _program name_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/37)
<!-- Reviewable:end -->
