### PR TITLE
Fixed sort direction

### DIFF
--- a/src/main/java/org/openlmis/utils/BasicRequisitionDtoComparator.java
+++ b/src/main/java/org/openlmis/utils/BasicRequisitionDtoComparator.java
@@ -78,7 +78,7 @@ public class BasicRequisitionDtoComparator implements Comparator<BasicRequisitio
         );
       }
 
-      chain.addComparator(comparator, order.isAscending());
+      chain.addComparator(comparator, !order.isAscending());
     }
 
     return chain.compare(o1, o2);


### PR DESCRIPTION
It seems like the direction of sorting was opposite to selected so when a user chose to sort **descending**, the comparator sorted **ascending**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/38)
<!-- Reviewable:end -->
