### PR TITLE
MW-397 Error handling refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bug fixes added in a backwards-compatible manner:
 * [OLMIS-2788](https://openlmis.atlassian.net/browse/OLMIS-2788): Fixed print requisition.
 * [OLMIS-2747](https://openlmis.atlassian.net/browse/OLMIS-2747): Fixed bug preventing user from being able to re-initiate a requisition after being removed, when there's already a requisition for next period.
 * [OLMIS-2871](https://openlmis.atlassian.net/browse/OLMIS-2871): The service now uses an Authorization header instead of an access_token request parameter when communicating with other services.
+* [MW-397](https://openlmis.atlassian.net/browse/MW-397): Refactored the error handling.
 
 4.0.0 / 2017-06-23
 ==================

--- a/src/integration-test/java/org/openlmis/requisition/web/JasperTemplateControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/JasperTemplateControllerIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openlmis.requisition.domain.JasperTemplate;
 import org.openlmis.requisition.dto.JasperTemplateDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 import org.openlmis.requisition.exception.JasperReportViewException;
 import org.openlmis.requisition.repository.JasperTemplateRepository;
 import org.openlmis.requisition.service.JasperReportsViewService;
@@ -38,14 +40,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.view.jasperreports.JasperReportsMultiFormatView;
 
+import guru.nidi.ramltester.junit.RamlMatchers;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.UUID;
 
 import javax.servlet.http.HttpServletRequest;
-
-import guru.nidi.ramltester.junit.RamlMatchers;
 
 @SuppressWarnings("PMD.TooManyMethods")
 public class JasperTemplateControllerIntegrationTest extends BaseWebIntegrationTest {
@@ -64,6 +66,8 @@ public class JasperTemplateControllerIntegrationTest extends BaseWebIntegrationT
   @Before
   public void setUp() {
     mockUserAuthenticated();
+    doReturn(ValidationResult.success()).when(permissionService).canEditReportTemplates();
+    doReturn(ValidationResult.success()).when(permissionService).canViewReports();
   }
 
   // GET /api/reports/templates/requisitions

--- a/src/integration-test/java/org/openlmis/requisition/web/ReportsControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/ReportsControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anySetOf;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import org.joda.money.CurrencyUnit;
@@ -45,6 +46,7 @@ import org.openlmis.requisition.dto.RequisitionLineItemDto;
 import org.openlmis.requisition.dto.RequisitionReportDto;
 import org.openlmis.requisition.dto.SupportedProgramDto;
 import org.openlmis.requisition.dto.UserDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 import org.openlmis.requisition.repository.RequisitionRepository;
 import org.openlmis.requisition.service.referencedata.OrderableReferenceDataService;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -85,6 +87,7 @@ public class ReportsControllerIntegrationTest extends BaseWebIntegrationTest {
     mockUserAuthenticated();
     given(orderableReferenceDataService.findByIds(anySetOf(UUID.class))).willReturn(
             Collections.emptyList());
+    doReturn(ValidationResult.success()).when(permissionService).canViewRequisition(anyUuid());
   }
 
   // GET /api/requisitions/{id}/print

--- a/src/integration-test/java/org/openlmis/requisition/web/StatusMessageControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/StatusMessageControllerIntegrationTest.java
@@ -19,7 +19,7 @@ package org.openlmis.requisition.web;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doReturn;
 import static org.openlmis.requisition.service.PermissionService.REQUISITION_VIEW;
 
 import org.junit.Before;
@@ -28,15 +28,16 @@ import org.openlmis.requisition.domain.Requisition;
 import org.openlmis.requisition.domain.RequisitionStatus;
 import org.openlmis.requisition.domain.StatusMessage;
 import org.openlmis.requisition.dto.StatusMessageDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 import org.openlmis.requisition.repository.StatusMessageRepository;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+
+import guru.nidi.ramltester.junit.RamlMatchers;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
-import guru.nidi.ramltester.junit.RamlMatchers;
-import org.springframework.http.HttpHeaders;
 
 public class StatusMessageControllerIntegrationTest extends BaseWebIntegrationTest {
 
@@ -61,6 +62,8 @@ public class StatusMessageControllerIntegrationTest extends BaseWebIntegrationTe
 
     List<StatusMessage> messages = Collections.singletonList(message);
     given(statusMessageRepository.findByRequisitionId(requisition.getId())).willReturn(messages);
+    doReturn(ValidationResult.success()).when(
+        permissionService).canViewRequisition(requisition.getId());
 
     // when
     StatusMessageDto[] result = restAssured.given()
@@ -83,7 +86,7 @@ public class StatusMessageControllerIntegrationTest extends BaseWebIntegrationTe
   public void shouldReturn403WhenUserHasNoRightsToViewRequisitionOfStatusMessage() {
     // given
     Requisition requisition = generateRequisition(RequisitionStatus.AUTHORIZED);
-    doThrow(mockPermissionException(REQUISITION_VIEW))
+    doReturn(ValidationResult.noPermission(PERMISSION_ERROR_MESSAGE, REQUISITION_VIEW))
         .when(permissionService).canViewRequisition(requisition.getId());
 
     // when

--- a/src/main/java/org/openlmis/requisition/domain/RequisitionStatus.java
+++ b/src/main/java/org/openlmis/requisition/domain/RequisitionStatus.java
@@ -39,6 +39,11 @@ public enum RequisitionStatus {
   }
 
   @JsonIgnore
+  public boolean isUpdatable() {
+    return value < 4 && value != -1;
+  }
+
+  @JsonIgnore
   public boolean isPreAuthorize() {
     return value == 1 || value == 2;
   }

--- a/src/main/java/org/openlmis/requisition/errorhandling/FailureType.java
+++ b/src/main/java/org/openlmis/requisition/errorhandling/FailureType.java
@@ -1,0 +1,23 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.errorhandling;
+
+public enum FailureType {
+  VALIDATION,
+  NOT_FOUND,
+  NO_PERMISSION,
+  CONFLICT
+}

--- a/src/main/java/org/openlmis/requisition/errorhandling/ValidationFailure.java
+++ b/src/main/java/org/openlmis/requisition/errorhandling/ValidationFailure.java
@@ -1,0 +1,28 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.errorhandling;
+
+import org.openlmis.utils.Message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ValidationFailure {
+  private Message message;
+  private FailureType type;
+}

--- a/src/main/java/org/openlmis/requisition/errorhandling/ValidationResult.java
+++ b/src/main/java/org/openlmis/requisition/errorhandling/ValidationResult.java
@@ -1,0 +1,164 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.errorhandling;
+
+import static org.openlmis.requisition.errorhandling.FailureType.CONFLICT;
+import static org.openlmis.requisition.errorhandling.FailureType.NOT_FOUND;
+import static org.openlmis.requisition.errorhandling.FailureType.NO_PERMISSION;
+import static org.openlmis.requisition.errorhandling.FailureType.VALIDATION;
+
+import org.openlmis.requisition.exception.ContentNotFoundMessageException;
+import org.openlmis.requisition.exception.ValidationMessageException;
+import org.openlmis.requisition.exception.VersionMismatchException;
+import org.openlmis.requisition.web.PermissionMessageException;
+import org.openlmis.utils.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ValidationResult {
+
+  private List<ValidationFailure> errors;
+
+  public ValidationResult() {
+    this.errors = new ArrayList<>();
+  }
+
+  /**
+   * Creates a ValidationResult for a check that failed on validation.
+   *
+   * @param messageKey a message key to include in the error or exception
+   * @param msgParameters parameters for the given message
+   * @return a ValidationResult instance containing validation error
+   */
+  public static ValidationResult failedValidation(String messageKey, Object... msgParameters) {
+    ValidationResult result = new ValidationResult();
+    result.addError(new Message(messageKey, msgParameters), VALIDATION);
+    return result;
+  }
+
+  /**
+   * Creates a ValidationResult for a check that failed on validation.
+   *
+   * @param messageKey a message key to include in the error or exception
+   * @param msgParameters parameters for the given message
+   * @return a ValidationResult instance containing not found error
+   */
+  public static ValidationResult notFound(String messageKey, Object... msgParameters) {
+    ValidationResult result = new ValidationResult();
+    result.addError(new Message(messageKey, msgParameters), NOT_FOUND);
+    return result;
+  }
+
+  /**
+   * Creates a ValidationResult for a check that failed on validation.
+   *
+   * @param messageKey a message key to include in the error or exception
+   * @param msgParameters parameters for the given message
+   * @return a ValidationResult instance containing permission error
+   */
+  public static ValidationResult noPermission(String messageKey, Object... msgParameters) {
+    ValidationResult result = new ValidationResult();
+    result.addError(new Message(messageKey, msgParameters), NO_PERMISSION);
+    return result;
+  }
+
+  /**
+   * Creates a ValidationResult for a check that failed on validation.
+   *
+   * @param messageKey a message key to include in the error or exception
+   * @param msgParameters parameters for the given message
+   * @return a ValidationResult instance containing conflict error
+   */
+  public static ValidationResult conflict(String messageKey, Object... msgParameters) {
+    ValidationResult result = new ValidationResult();
+    result.addError(new Message(messageKey, msgParameters), CONFLICT);
+    return result;
+  }
+
+  /**
+   * Creates a ValidationResult for a check that succeeded.
+
+   * @return a ValidationResult instance representing successful validation
+   */
+  public static ValidationResult success() {
+    return new ValidationResult();
+  }
+
+  /**
+   * Adds a new error to this validation result.
+   *
+   * @param message a message key to include in the error or exception
+   * @param type a type of an error
+   */
+  public void addError(Message message, FailureType type) {
+    this.errors.add(new ValidationFailure(message, type));
+  }
+
+  /**
+   * Checks if there are any errors in this validation result.
+   * @return true if there are any errors; false otherwise
+   */
+  public boolean hasErrors() {
+    return !isSuccess();
+  }
+
+  /**
+   * Checks if there are no errors in this validation result.
+   * @return true if there are no errors; false otherwise
+   */
+  public boolean isSuccess() {
+    return errors.isEmpty();
+  }
+
+  /**
+   * Retrieves all errors of this validation result.
+   * @return a list of errors
+   */
+  public List<ValidationFailure> gerErrors() {
+    return errors;
+  }
+
+  /**
+   * Retrieves first error from this validation result. It will return null if there are no errors.
+   * @return the first error of this validation result
+   */
+  public ValidationFailure getError() {
+    return errors.isEmpty() ? null : errors.get(0);
+  }
+
+  /**
+   * Throws exception for the first encountered error. The exception class depends on the type of
+   * the error.
+   */
+  public void throwExceptionIfHasErrors() {
+    if (hasErrors()) {
+      ValidationFailure failure = getError();
+
+      switch (failure.getType()) {
+        case VALIDATION:
+          throw new ValidationMessageException(failure.getMessage());
+        case NOT_FOUND:
+          throw new ContentNotFoundMessageException(failure.getMessage());
+        case NO_PERMISSION:
+          throw new PermissionMessageException(failure.getMessage());
+        case CONFLICT:
+          throw new VersionMismatchException(failure.getMessage());
+        default:
+      }
+    }
+  }
+}

--- a/src/main/java/org/openlmis/requisition/errorhandling/ValidationResult.java
+++ b/src/main/java/org/openlmis/requisition/errorhandling/ValidationResult.java
@@ -51,7 +51,8 @@ public class ValidationResult {
   }
 
   /**
-   * Creates a ValidationResult for a check that failed on validation.
+   * Creates a ValidationResult for a check that failed due to a reference to
+   * an instance that did not exist.
    *
    * @param messageKey a message key to include in the error or exception
    * @param msgParameters parameters for the given message
@@ -64,7 +65,8 @@ public class ValidationResult {
   }
 
   /**
-   * Creates a ValidationResult for a check that failed on validation.
+   * Creates a ValidationResult for a check that failed due to a user not having
+   * permissions to access the resource.
    *
    * @param messageKey a message key to include in the error or exception
    * @param msgParameters parameters for the given message
@@ -77,7 +79,7 @@ public class ValidationResult {
   }
 
   /**
-   * Creates a ValidationResult for a check that failed on validation.
+   * Creates a ValidationResult for a check that failed due to a conflict.
    *
    * @param messageKey a message key to include in the error or exception
    * @param msgParameters parameters for the given message

--- a/src/main/java/org/openlmis/requisition/service/PermissionService.java
+++ b/src/main/java/org/openlmis/requisition/service/PermissionService.java
@@ -26,17 +26,15 @@ import org.openlmis.requisition.dto.ConvertToOrderDto;
 import org.openlmis.requisition.dto.ResultDto;
 import org.openlmis.requisition.dto.RightDto;
 import org.openlmis.requisition.dto.UserDto;
-import org.openlmis.requisition.exception.ContentNotFoundMessageException;
-import org.openlmis.requisition.exception.ValidationMessageException;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 import org.openlmis.requisition.repository.RequisitionRepository;
 import org.openlmis.requisition.service.referencedata.UserReferenceDataService;
-import org.openlmis.requisition.web.PermissionMessageException;
 import org.openlmis.utils.AuthenticationHelper;
-import org.openlmis.utils.Message;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -68,24 +66,24 @@ public class PermissionService {
   /**
    * Checks if current user has permission to initiate a requisition.
    *
-   * @throws PermissionMessageException if the current user has not a permission.
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canInitRequisition(UUID program, UUID facility) {
-    checkPermission(REQUISITION_CREATE, program, facility, null);
+  public ValidationResult canInitRequisition(UUID program, UUID facility) {
+    return checkPermission(REQUISITION_CREATE, program, facility, null);
   }
 
   /**
    * Checks if current user has permission to initiate or authorize a requisition.
    *
-   * @throws PermissionMessageException if the current user has not a permission.
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canInitOrAuthorizeRequisition(UUID program, UUID facility) {
+  public ValidationResult canInitOrAuthorizeRequisition(UUID program, UUID facility) {
     if (!hasPermission(REQUISITION_CREATE, program, facility, null)
         && !hasPermission(REQUISITION_AUTHORIZE, program, facility, null)) {
-      throw new PermissionMessageException(
-          new Message(ERROR_NO_FOLLOWING_PERMISSION, REQUISITION_CREATE, REQUISITION_AUTHORIZE)
-      );
+      return ValidationResult.noPermission(
+          ERROR_NO_FOLLOWING_PERMISSION, REQUISITION_CREATE, REQUISITION_AUTHORIZE);
     }
+    return ValidationResult.success();
   }
 
   /**
@@ -93,75 +91,86 @@ public class PermissionService {
    * Permissions needed to perform update action depend on the requisition status.
    *
    * @param requisitionId UUID of requisition.
-   * @throws PermissionMessageException if the current user has not a permission.
-   * @throws IllegalStateException      if requisition has incorrect status.
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canUpdateRequisition(UUID requisitionId) {
+  public ValidationResult canUpdateRequisition(UUID requisitionId) {
     Requisition requisition = requisitionRepository.findOne(requisitionId);
 
     if (requisition != null) {
       switch (requisition.getStatus()) {
         case INITIATED:
         case REJECTED:
-          checkPermissionOnUpdate(REQUISITION_CREATE, requisition);
-          break;
+          return checkPermissionOnUpdate(REQUISITION_CREATE, requisition);
         case SUBMITTED:
-          checkPermissionOnUpdate(REQUISITION_AUTHORIZE, requisition);
-          break;
+          return checkPermissionOnUpdate(REQUISITION_AUTHORIZE, requisition);
         case AUTHORIZED:
         case IN_APPROVAL:
-          checkPermissionOnUpdate(REQUISITION_APPROVE, requisition);
-          break;
+          return checkPermissionOnUpdate(REQUISITION_APPROVE, requisition);
         default:
-          throw new ValidationMessageException(ERROR_CANNOT_UPDATE_REQUISITION);
+          return ValidationResult.failedValidation(ERROR_CANNOT_UPDATE_REQUISITION);
       }
     }
+
+    return ValidationResult.success();
   }
 
   /**
    * Checks if current user has permission to submit a requisition.
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canSubmitRequisition(UUID requisitionId) {
-    checkPermission(REQUISITION_CREATE, requisitionId);
+  public ValidationResult canSubmitRequisition(UUID requisitionId) {
+    return checkPermission(REQUISITION_CREATE, requisitionId);
   }
 
   /**
    * Checks if current user has permission to approve a requisition.
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canApproveRequisition(UUID requisitionId) {
-    checkPermission(REQUISITION_APPROVE, requisitionId);
+  public ValidationResult canApproveRequisition(UUID requisitionId) {
+    return checkPermission(REQUISITION_APPROVE, requisitionId);
   }
 
   /**
    * Checks if current user has permission to authorize a requisition.
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canAuthorizeRequisition(UUID requisitionId) {
-    checkPermission(REQUISITION_AUTHORIZE, requisitionId);
+  public ValidationResult canAuthorizeRequisition(UUID requisitionId) {
+    return checkPermission(REQUISITION_AUTHORIZE, requisitionId);
   }
 
   /**
    * Checks if current user has permission to delete a requisition.
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canDeleteRequisition(UUID requisitionId) {
+  public ValidationResult canDeleteRequisition(UUID requisitionId) {
     Requisition requisition = requisitionRepository.findOne(requisitionId);
     if (requisition != null) {
-      checkPermission(REQUISITION_DELETE, requisition);
+      ValidationResult permissionCheck = checkPermission(REQUISITION_DELETE, requisition);
+      if (permissionCheck.hasErrors()) {
+        return permissionCheck;
+      }
       if (requisition.getStatus().isSubmittable()) {
-        checkPermission(REQUISITION_CREATE, requisition);
+        return checkPermission(REQUISITION_CREATE, requisition);
       } else if (requisition.getStatus().equals(RequisitionStatus.SUBMITTED)) {
-        checkPermission(REQUISITION_AUTHORIZE, requisition);
+        return checkPermission(REQUISITION_AUTHORIZE, requisition);
       }
     } else {
-      throw new ContentNotFoundMessageException(new Message(ERROR_REQUISITION_NOT_FOUND,
-          requisitionId));
+      return ValidationResult.notFound(ERROR_REQUISITION_NOT_FOUND, requisitionId);
     }
+    return ValidationResult.success();
   }
 
   /**
    * Checks if current user has permission to view a requisition.
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canViewRequisition(UUID requisitionId) {
-    checkPermission(REQUISITION_VIEW, requisitionId);
+  public ValidationResult canViewRequisition(UUID requisitionId) {
+    return checkPermission(REQUISITION_VIEW, requisitionId);
   }
 
   /**
@@ -177,65 +186,84 @@ public class PermissionService {
    * Checks if current user has permission to convert requisition to order.
    *
    * @param list of ConvertToOrderDtos containing chosen requisitionId and supplyingDepotId.
-   * @throws PermissionMessageException if the current user has not a permission.
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canConvertToOrder(List<ConvertToOrderDto> list) {
+  public ValidationResult canConvertToOrder(List<ConvertToOrderDto> list) {
     for (ConvertToOrderDto convertToOrder : list) {
       Requisition requisition = requisitionRepository.findOne(convertToOrder.getRequisitionId());
       if (requisition == null) {
-        throw new ContentNotFoundMessageException(new Message(ERROR_REQUISITION_NOT_FOUND,
-            convertToOrder.getRequisitionId()));
+        return ValidationResult.notFound(
+            ERROR_REQUISITION_NOT_FOUND, convertToOrder.getRequisitionId());
       }
-      checkPermission(ORDERS_EDIT, null, null, convertToOrder.getSupplyingDepotId());
+      ValidationResult validation = checkPermission(ORDERS_EDIT, null, null,
+          convertToOrder.getSupplyingDepotId());
+      if (validation.hasErrors()) {
+        return validation;
+      }
     }
+    return ValidationResult.success();
   }
 
   /**
    * Checks if current user has permission to manage a requisition template.
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public void canManageRequisitionTemplate() {
-    checkPermission(REQUISITION_TEMPLATES_MANAGE, null, null, null);
+  public ValidationResult canManageRequisitionTemplate() {
+    return checkPermission(REQUISITION_TEMPLATES_MANAGE, null, null, null);
   }
 
-  public void canEditReportTemplates() {
-    checkPermission(REPORT_TEMPLATES_EDIT, null, null, null);
+  /**
+   * Checks if current user has permission to edit a report template.
+   *
+   * @return ValidationResult containing info about the result of this check
+   */
+  public ValidationResult canEditReportTemplates() {
+    return checkPermission(REPORT_TEMPLATES_EDIT, null, null, null);
   }
 
-  public void canViewReports() {
-    checkPermission(REPORTS_VIEW, null, null, null);
+  /**
+   * Checks if current user has permission to view a report template.
+   *
+   * @return ValidationResult containing info about the result of this check
+   */
+  public ValidationResult canViewReports() {
+    return checkPermission(REPORTS_VIEW, null, null, null);
   }
 
-  private void checkPermissionOnUpdate(String rightName, Requisition requisition) {
+  private ValidationResult checkPermissionOnUpdate(String rightName, Requisition requisition) {
     if (!hasPermission(rightName, requisition.getProgramId(), requisition.getFacilityId(), null)) {
       RequisitionStatus status = requisition.getStatus();
       if (status.duringApproval()) {
         status = RequisitionStatus.AUTHORIZED;
       }
-      throw new PermissionMessageException(
-          new Message(ERROR_NO_FOLLOWING_PERMISSION_FOR_REQUISITION_UPDATE,
-              status.toString(), rightName));
+      return ValidationResult.noPermission(
+          ERROR_NO_FOLLOWING_PERMISSION_FOR_REQUISITION_UPDATE, status.toString(), rightName);
     }
+    return ValidationResult.success();
   }
 
-  private void checkPermission(String rightName, UUID requisitionId) {
+  private ValidationResult checkPermission(String rightName, UUID requisitionId) {
     Requisition requisition = requisitionRepository.findOne(requisitionId);
 
     if (null != requisition) {
-      checkPermission(rightName, requisition);
+      return checkPermission(rightName, requisition);
     } else {
-      throw new ContentNotFoundMessageException(new Message(ERROR_REQUISITION_NOT_FOUND,
-          requisitionId));
+      return ValidationResult.notFound(ERROR_REQUISITION_NOT_FOUND, requisitionId);
     }
   }
 
-  private void checkPermission(String rightName, Requisition requisition) {
-    checkPermission(rightName, requisition.getProgramId(), requisition.getFacilityId(), null);
+  private ValidationResult checkPermission(String rightName, Requisition requisition) {
+    return checkPermission(
+        rightName, requisition.getProgramId(), requisition.getFacilityId(), null);
   }
 
-  private void checkPermission(String rightName, UUID program, UUID facility, UUID warehouse) {
+  private ValidationResult checkPermission(String rightName, UUID program, UUID facility,
+                                           UUID warehouse) {
     if (!hasPermission(rightName, program, facility, warehouse)) {
-      throw new PermissionMessageException(new Message(ERROR_NO_FOLLOWING_PERMISSION, rightName));
+      return ValidationResult.noPermission(ERROR_NO_FOLLOWING_PERMISSION, rightName);
     }
+    return ValidationResult.success();
   }
 
   private Boolean hasPermission(String rightName, UUID program, UUID facility, UUID warehouse) {

--- a/src/main/java/org/openlmis/requisition/service/RequisitionService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionService.java
@@ -19,7 +19,6 @@ import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.BooleanUtils.isNotTrue;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.openlmis.requisition.domain.RequisitionStatus.APPROVED;
-import static org.openlmis.requisition.domain.RequisitionStatus.RELEASED;
 import static org.openlmis.requisition.domain.RequisitionStatus.SKIPPED;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_CANNOT_UPDATE_WITH_STATUS;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_DELETE_FAILED_WRONG_STATUS;
@@ -477,7 +476,7 @@ public class RequisitionService {
     }
 
     RequisitionStatus status = requisitionToUpdate.getStatus();
-    if (status == APPROVED || status == SKIPPED || status == RELEASED) {
+    if (!status.isUpdatable()) {
       return ValidationResult.failedValidation(ERROR_CANNOT_UPDATE_WITH_STATUS,
           requisitionToUpdate.getStatus());
     }

--- a/src/main/java/org/openlmis/requisition/validate/RequisitionVersionValidator.java
+++ b/src/main/java/org/openlmis/requisition/validate/RequisitionVersionValidator.java
@@ -34,7 +34,7 @@ public class RequisitionVersionValidator {
 
   /**
    * Validates if the date modified of the incoming requisition matches
-   * the date modified of the existing requisition If the incoming requisition has
+   * the date modified of the existing requisition. If the incoming requisition has
    * no modified date, that will not trigger the exception.
    * @param incomingReq the requisition to validate
    * @param existingReq the existing version of the requisition

--- a/src/main/java/org/openlmis/requisition/validate/RequisitionVersionValidator.java
+++ b/src/main/java/org/openlmis/requisition/validate/RequisitionVersionValidator.java
@@ -18,7 +18,7 @@ package org.openlmis.requisition.validate;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_DATE_MODIFIED_MISMATCH;
 
 import org.openlmis.requisition.domain.Requisition;
-import org.openlmis.requisition.exception.VersionMismatchException;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 import org.springframework.stereotype.Component;
 
 import java.time.ZonedDateTime;
@@ -34,18 +34,19 @@ public class RequisitionVersionValidator {
 
   /**
    * Validates if the date modified of the incoming requisition matches
-   * the date modified of the existing requisition. If not, a
-   * {@link VersionMismatchException} is thrown. If the incoming requisition has
+   * the date modified of the existing requisition If the incoming requisition has
    * no modified date, that will not trigger the exception.
    * @param incomingReq the requisition to validate
    * @param existingReq the existing version of the requisition
+   * @return ValidationResult that contains outcome of this validation
    */
-  public void validateRequisitionTimestamps(Requisition incomingReq,
-                                            Requisition existingReq) {
+  public ValidationResult validateRequisitionTimestamps(Requisition incomingReq,
+                                                        Requisition existingReq) {
     ZonedDateTime dateModified = incomingReq.getModifiedDate();
     if (dateModified != null
         && !dateModified.isEqual(existingReq.getModifiedDate())) {
-      throw new VersionMismatchException(ERROR_DATE_MODIFIED_MISMATCH);
+      return ValidationResult.conflict(ERROR_DATE_MODIFIED_MISMATCH);
     }
+    return ValidationResult.success();
   }
 }

--- a/src/main/java/org/openlmis/requisition/web/JasperTemplateController.java
+++ b/src/main/java/org/openlmis/requisition/web/JasperTemplateController.java
@@ -80,7 +80,7 @@ public class JasperTemplateController extends BaseController {
   public void createJasperReportTemplate(
       @RequestPart("file") MultipartFile file, String name, String description)
       throws ReportingException {
-    permissionService.canEditReportTemplates();
+    permissionService.canEditReportTemplates().throwExceptionIfHasErrors();
 
     JasperTemplate jasperTemplateToUpdate = jasperTemplateRepository.findByName(name);
     if (jasperTemplateToUpdate == null) {
@@ -106,7 +106,7 @@ public class JasperTemplateController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public Iterable<JasperTemplateDto> getAllTemplates() {
-    permissionService.canViewReports();
+    permissionService.canViewReports().throwExceptionIfHasErrors();
     Iterable<JasperTemplateDto> templates =
         JasperTemplateDto.newInstance(jasperTemplateRepository.findAll());
     return templates;
@@ -122,7 +122,7 @@ public class JasperTemplateController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public JasperTemplateDto getTemplate(@PathVariable("id") UUID templateId) {
-    permissionService.canViewReports();
+    permissionService.canViewReports().throwExceptionIfHasErrors();
     JasperTemplate jasperTemplate =
         jasperTemplateRepository.findOne(templateId);
     if (jasperTemplate == null) {
@@ -141,7 +141,7 @@ public class JasperTemplateController extends BaseController {
   @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteTemplate(@PathVariable("id") UUID templateId) {
-    permissionService.canEditReportTemplates();
+    permissionService.canEditReportTemplates().throwExceptionIfHasErrors();
     JasperTemplate jasperTemplate = jasperTemplateRepository.findOne(templateId);
     if (jasperTemplate == null) {
       throw new ContentNotFoundMessageException(new Message(
@@ -164,7 +164,7 @@ public class JasperTemplateController extends BaseController {
   public ModelAndView generateReport(HttpServletRequest request,
       @PathVariable("id") UUID templateId,
       @PathVariable("format") String format) throws JasperReportViewException {
-    permissionService.canViewReports();
+    permissionService.canViewReports().throwExceptionIfHasErrors();
 
     JasperTemplate template = jasperTemplateRepository.findOne(templateId);
     if (template == null) {

--- a/src/main/java/org/openlmis/requisition/web/ReportsController.java
+++ b/src/main/java/org/openlmis/requisition/web/ReportsController.java
@@ -58,7 +58,7 @@ public class ReportsController extends BaseController {
   @ResponseBody
   public ModelAndView print(HttpServletRequest request, @PathVariable("id") UUID id)
       throws JasperReportViewException {
-    permissionService.canViewRequisition(id);
+    permissionService.canViewRequisition(id).throwExceptionIfHasErrors();
 
     Requisition requisition = requisitionRepository.findOne(id);
     if (requisition == null) {

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -311,7 +311,7 @@ public class RequisitionController extends BaseController {
     draftValidator.validate(requisition, bindingResult);
 
     if (bindingResult.hasErrors()) {
-      LOGGER.warn("Validation for requisition failedValidation: {}", getErrors(bindingResult));
+      LOGGER.warn("Validation for requisition failed: {}", getErrors(bindingResult));
       throw new BindingResultException(getErrors(bindingResult));
     }
 

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -252,7 +252,7 @@ public class RequisitionController extends BaseController {
     validator.validate(requisition, bindingResult);
 
     if (bindingResult.hasErrors()) {
-      LOGGER.warn("Validation for requisition failedValidation: {}", getErrors(bindingResult));
+      LOGGER.warn("Validation for requisition failed: {}", getErrors(bindingResult));
       throw new BindingResultException(getErrors(bindingResult));
     }
 
@@ -424,7 +424,7 @@ public class RequisitionController extends BaseController {
     BindingResult bindingResult = new BeanPropertyBindingResult(requisition, REQUISITION);
     validator.validate(requisition, bindingResult);
     if (bindingResult.hasErrors()) {
-      LOGGER.warn("Validation for requisition failedValidation: {}", getErrors(bindingResult));
+      LOGGER.warn("Validation for requisition failed: {}", getErrors(bindingResult));
       throw new BindingResultException(getErrors(bindingResult));
     }
 

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -15,13 +15,8 @@
 
 package org.openlmis.requisition.web;
 
-import static java.util.Objects.isNull;
-import static org.apache.commons.lang3.BooleanUtils.isNotTrue;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_AUTHORIZATION_TO_BE_SKIPPED;
-import static org.openlmis.requisition.i18n.MessageKeys.ERROR_CANNOT_UPDATE_WITH_STATUS;
-import static org.openlmis.requisition.i18n.MessageKeys.ERROR_ID_MISMATCH;
-import static org.openlmis.requisition.i18n.MessageKeys.ERROR_REQUISITION_NOT_FOUND;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
@@ -87,6 +82,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -201,7 +197,7 @@ public class RequisitionController extends BaseController {
           new Message(MessageKeys.ERROR_PROGRAM_NOT_FOUND, programId));
     }
 
-    permissionService.canInitRequisition(programId, facilityId);
+    permissionService.canInitRequisition(programId, facilityId).throwExceptionIfHasErrors();
     facilitySupportsProgramHelper.checkIfFacilitySupportsProgram(facility, programId);
 
     Requisition newRequisition = requisitionService
@@ -229,7 +225,7 @@ public class RequisitionController extends BaseController {
           new Message(MessageKeys.ERROR_REQUISITION_PERIODS_FOR_INITIATE_MISSING_PARAMETERS));
     }
 
-    permissionService.canInitOrAuthorizeRequisition(program, facility);
+    permissionService.canInitOrAuthorizeRequisition(program, facility).throwExceptionIfHasErrors();
 
     facilitySupportsProgramHelper.checkIfFacilitySupportsProgram(facility, program);
 
@@ -245,7 +241,7 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public BasicRequisitionDto submitRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canSubmitRequisition(requisitionId);
+    permissionService.canSubmitRequisition(requisitionId).throwExceptionIfHasErrors();
     Requisition requisition = requisitionRepository.findOne(requisitionId);
     if (requisition == null) {
       throw new ContentNotFoundMessageException(
@@ -256,12 +252,9 @@ public class RequisitionController extends BaseController {
     validator.validate(requisition, bindingResult);
 
     if (bindingResult.hasErrors()) {
-      LOGGER.warn("Validation for requisition failed: {}", getErrors(bindingResult));
+      LOGGER.warn("Validation for requisition failedValidation: {}", getErrors(bindingResult));
       throw new BindingResultException(getErrors(bindingResult));
     }
-
-    facilitySupportsProgramHelper.checkIfFacilitySupportsProgram(requisition.getFacilityId(),
-        requisition.getProgramId());
 
     LOGGER.debug("Submitting a requisition with id " + requisition.getId());
 
@@ -284,7 +277,7 @@ public class RequisitionController extends BaseController {
   @RequestMapping(value = "/requisitions/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canDeleteRequisition(requisitionId);
+    permissionService.canDeleteRequisition(requisitionId).throwExceptionIfHasErrors();
     requisitionService.delete(requisitionId);
   }
 
@@ -300,56 +293,37 @@ public class RequisitionController extends BaseController {
   @ResponseBody
   public RequisitionDto updateRequisition(@RequestBody RequisitionDto requisitionDto,
                                           @PathVariable("id") UUID requisitionId) {
-    permissionService.canUpdateRequisition(requisitionId);
-
-    if (isNotTrue(isNull(requisitionDto.getId()))
-        && isNotTrue(requisitionId.equals(requisitionDto.getId()))) {
-      throw new ValidationMessageException(new Message(ERROR_ID_MISMATCH));
-    }
+    requisitionService.validateCanSaveRequisition(requisitionDto, requisitionId)
+        .throwExceptionIfHasErrors();
 
     Requisition requisitionToUpdate = requisitionRepository.findOne(requisitionId);
-
-    if (isNull(requisitionToUpdate)) {
-      throw new ContentNotFoundMessageException(new Message(
-          ERROR_REQUISITION_NOT_FOUND, requisitionId));
-    }
-
     Requisition requisition = RequisitionBuilder.newRequisition(requisitionDto,
         requisitionToUpdate.getTemplate(), requisitionToUpdate.getProgramId(),
         requisitionToUpdate.getStatus());
     requisition.setId(requisitionId);
 
-    requisitionVersionValidator.validateRequisitionTimestamps(
-        requisition, requisitionToUpdate
-    );
+    requisitionVersionValidator.validateRequisitionTimestamps(requisition, requisitionToUpdate)
+        .throwExceptionIfHasErrors();
 
-    RequisitionStatus status = requisitionToUpdate.getStatus();
-    if (status != RequisitionStatus.APPROVED
-        && status != RequisitionStatus.SKIPPED
-        && status != RequisitionStatus.RELEASED) {
-      LOGGER.debug("Updating requisition with id: {}", requisitionId);
+    LOGGER.debug("Updating requisition with id: {}", requisitionId);
 
-      BindingResult bindingResult = new BeanPropertyBindingResult(requisition, REQUISITION);
-      draftValidator.validate(requisition, bindingResult);
+    BindingResult bindingResult = new BeanPropertyBindingResult(requisition, REQUISITION);
+    draftValidator.validate(requisition, bindingResult);
 
-      if (bindingResult.hasErrors()) {
-        LOGGER.warn("Validation for requisition failed: {}", getErrors(bindingResult));
-        throw new BindingResultException(getErrors(bindingResult));
-      }
-
-      requisitionToUpdate.updateFrom(requisition,
-          stockAdjustmentReasonReferenceDataService.getStockAdjustmentReasonsByProgram(
-              requisitionToUpdate.getProgramId()), orderableReferenceDataService.findByIds(
-                      getLineItemOrderableIds(requisition)));
-
-      requisitionToUpdate = requisitionRepository.save(requisitionToUpdate);
-
-      LOGGER.debug("Saved requisition with id: " + requisitionToUpdate.getId());
-      return requisitionDtoBuilder.build(requisitionToUpdate);
-    } else {
-      throw new ValidationMessageException(new Message(ERROR_CANNOT_UPDATE_WITH_STATUS,
-          requisitionToUpdate.getStatus()));
+    if (bindingResult.hasErrors()) {
+      LOGGER.warn("Validation for requisition failedValidation: {}", getErrors(bindingResult));
+      throw new BindingResultException(getErrors(bindingResult));
     }
+
+    requisitionToUpdate.updateFrom(requisition,
+        stockAdjustmentReasonReferenceDataService.getStockAdjustmentReasonsByProgram(
+            requisitionToUpdate.getProgramId()), orderableReferenceDataService.findByIds(
+                    getLineItemOrderableIds(requisition)));
+
+    requisitionToUpdate = requisitionRepository.save(requisitionToUpdate);
+
+    LOGGER.debug("Saved requisition with id: " + requisitionToUpdate.getId());
+    return requisitionDtoBuilder.build(requisitionToUpdate);
   }
 
   /**
@@ -362,7 +336,7 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public RequisitionDto getRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canViewRequisition(requisitionId);
+    permissionService.canViewRequisition(requisitionId).throwExceptionIfHasErrors();
     Requisition requisition = requisitionRepository.findOne(requisitionId);
     if (requisition == null) {
       throw new ContentNotFoundMessageException(
@@ -410,7 +384,7 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public BasicRequisitionDto skipRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canUpdateRequisition(requisitionId);
+    permissionService.canUpdateRequisition(requisitionId).throwExceptionIfHasErrors();
 
     Requisition requisition = requisitionService.skip(requisitionId);
     requisitionStatusProcessor.statusChange(requisition);
@@ -424,7 +398,7 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public BasicRequisitionDto rejectRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canApproveRequisition(requisitionId);
+    permissionService.canApproveRequisition(requisitionId).throwExceptionIfHasErrors();
     Requisition rejectedRequisition = requisitionService.reject(requisitionId);
     requisitionStatusProcessor.statusChange(rejectedRequisition);
 
@@ -440,55 +414,24 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public BasicRequisitionDto approveRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canApproveRequisition(requisitionId);
+
     Requisition requisition = requisitionRepository.findOne(requisitionId);
-    if (requisition == null) {
-      throw new ContentNotFoundMessageException(
-          new Message(MessageKeys.ERROR_REQUISITION_NOT_FOUND, requisitionId));
-    }
+    UUID userId = authenticationHelper.getCurrentUser().getId();
+
+    requisitionService.validateCanApproveRequisition(requisition, requisitionId, userId)
+        .throwExceptionIfHasErrors();
 
     BindingResult bindingResult = new BeanPropertyBindingResult(requisition, REQUISITION);
     validator.validate(requisition, bindingResult);
-
     if (bindingResult.hasErrors()) {
-      LOGGER.warn("Validation for requisition failed: {}", getErrors(bindingResult));
+      LOGGER.warn("Validation for requisition failedValidation: {}", getErrors(bindingResult));
       throw new BindingResultException(getErrors(bindingResult));
     }
-    facilitySupportsProgramHelper.checkIfFacilitySupportsProgram(requisition.getFacilityId(),
-        requisition.getProgramId());
 
-    if (requisition.isApprovable()
-        || (configurationSettingService.getSkipAuthorization()
-        && requisition.getStatus() == RequisitionStatus.SUBMITTED)) {
+    SupervisoryNodeDto supervisoryNodeDto =
+        supervisoryNodeReferenceDataService.findOne(requisition.getSupervisoryNodeId());
 
-      SupervisoryNodeDto supervisoryNodeDto =
-          supervisoryNodeReferenceDataService.findOne(requisition.getSupervisoryNodeId());
-      UUID userId = authenticationHelper.getCurrentUser().getId();
-
-      requisitionService.checkIfCanApproveRequisition(requisition.getProgramId(),
-          supervisoryNodeDto != null ? supervisoryNodeDto.getId() : null, userId);
-
-      UUID parentNodeId = null;
-      if (supervisoryNodeDto != null) {
-        SupervisoryNodeDto parentNode = supervisoryNodeDto.getParentNode();
-        if (parentNode != null) {
-          parentNodeId = parentNode.getId();
-        }
-      }
-
-      requisition.approve(parentNodeId, orderableReferenceDataService.findByIds(
-              getLineItemOrderableIds(requisition)), userId);
-
-      saveStatusMessage(requisition);
-
-      requisitionRepository.save(requisition);
-      requisitionStatusProcessor.statusChange(requisition);
-      LOGGER.debug("Requisition with id " + requisitionId + " approved");
-      return basicRequisitionDtoBuilder.build(requisition);
-    } else {
-      throw new ValidationMessageException(new Message(
-          MessageKeys.ERROR_REQUISITION_MUST_BE_AUTHORIZED_OR_SUBMITTED, requisitionId));
-    }
+    return markAsApproved(requisition, userId, supervisoryNodeDto);
   }
 
   /**
@@ -540,7 +483,7 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public BasicRequisitionDto authorizeRequisition(@PathVariable("id") UUID requisitionId) {
-    permissionService.canAuthorizeRequisition(requisitionId);
+    permissionService.canAuthorizeRequisition(requisitionId).throwExceptionIfHasErrors();
 
     if (configurationSettingService.getSkipAuthorization()) {
       throw new ValidationMessageException(new Message(ERROR_AUTHORIZATION_TO_BE_SKIPPED));
@@ -559,8 +502,6 @@ public class RequisitionController extends BaseController {
     if (bindingResult.hasErrors()) {
       throw new BindingResultException(getErrors(bindingResult));
     }
-    facilitySupportsProgramHelper.checkIfFacilitySupportsProgram(requisition.getFacilityId(),
-        requisition.getProgramId());
 
     UserDto user = authenticationHelper.getCurrentUser();
 
@@ -617,7 +558,7 @@ public class RequisitionController extends BaseController {
   @ResponseStatus(HttpStatus.CREATED)
   public void convertToOrder(@RequestBody List<ConvertToOrderDto> list) {
     UserDto user = authenticationHelper.getCurrentUser();
-    permissionService.canConvertToOrder(list);
+    permissionService.canConvertToOrder(list).throwExceptionIfHasErrors();
     requisitionService.convertToOrder(list, user);
   }
 
@@ -636,6 +577,27 @@ public class RequisitionController extends BaseController {
       statusMessageRepository.save(newStatusMessage);
       requisition.setDraftStatusMessage("");
     }
+  }
+
+  protected BasicRequisitionDto markAsApproved(Requisition requisition, UUID userId,
+                                               SupervisoryNodeDto supervisoryNodeDto) {
+    UUID parentNodeId = null;
+    if (supervisoryNodeDto != null) {
+      SupervisoryNodeDto parentNode = supervisoryNodeDto.getParentNode();
+      if (parentNode != null) {
+        parentNodeId = parentNode.getId();
+      }
+    }
+
+    requisition.approve(parentNodeId, orderableReferenceDataService.findByIds(
+        getLineItemOrderableIds(requisition)), userId);
+
+    saveStatusMessage(requisition);
+
+    requisitionRepository.save(requisition);
+    requisitionStatusProcessor.statusChange(requisition);
+    LOGGER.debug("Requisition with id " + requisition.getId() + " approved");
+    return basicRequisitionDtoBuilder.build(requisition);
   }
 
   private Set<UUID> getLineItemOrderableIds(Requisition requisition) {

--- a/src/main/java/org/openlmis/requisition/web/RequisitionTemplateController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionTemplateController.java
@@ -72,7 +72,7 @@ public class RequisitionTemplateController extends BaseController {
   @ResponseBody
   public RequisitionTemplateDto createRequisitionTemplate(
       @RequestBody RequisitionTemplateDto requisitionTemplateDto, BindingResult bindingResult) {
-    permissionService.canManageRequisitionTemplate();
+    permissionService.canManageRequisitionTemplate().throwExceptionIfHasErrors();
 
     RequisitionTemplate requisitionTemplate =
         RequisitionTemplate.newInstance(requisitionTemplateDto);
@@ -99,7 +99,7 @@ public class RequisitionTemplateController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public Iterable<RequisitionTemplateDto> getAllRequisitionTemplates() {
-    permissionService.canManageRequisitionTemplate();
+    permissionService.canManageRequisitionTemplate().throwExceptionIfHasErrors();
 
     return RequisitionTemplateDto.newInstance(requisitionTemplateRepository.findAll());
   }
@@ -119,7 +119,7 @@ public class RequisitionTemplateController extends BaseController {
       @PathVariable("id") UUID requisitionTemplateId,
       @RequestBody RequisitionTemplateDto requisitionTemplateDto,
       BindingResult bindingResult) {
-    permissionService.canManageRequisitionTemplate();
+    permissionService.canManageRequisitionTemplate().throwExceptionIfHasErrors();
 
     RequisitionTemplate requisitionTemplate =
         RequisitionTemplate.newInstance(requisitionTemplateDto);
@@ -158,7 +158,7 @@ public class RequisitionTemplateController extends BaseController {
   @ResponseBody
   public RequisitionTemplateDto getRequisitionTemplate(
       @PathVariable("id") UUID requisitionTemplateId) {
-    permissionService.canManageRequisitionTemplate();
+    permissionService.canManageRequisitionTemplate().throwExceptionIfHasErrors();
 
     RequisitionTemplate requisitionTemplate =
         requisitionTemplateRepository.findOne(requisitionTemplateId);
@@ -178,7 +178,7 @@ public class RequisitionTemplateController extends BaseController {
   @RequestMapping(value = "/requisitionTemplates/{id}", method = RequestMethod.DELETE)
   @ResponseStatus(HttpStatus.NO_CONTENT)
   public void deleteRequisitionTemplate(@PathVariable("id") UUID requisitionTemplateId) {
-    permissionService.canManageRequisitionTemplate();
+    permissionService.canManageRequisitionTemplate().throwExceptionIfHasErrors();
     RequisitionTemplate requisitionTemplate =
         requisitionTemplateRepository.findOne(requisitionTemplateId);
     if (requisitionTemplate == null) {
@@ -200,7 +200,7 @@ public class RequisitionTemplateController extends BaseController {
   @ResponseBody
   public RequisitionTemplateDto getTemplateByProgram(
       @RequestParam(value = "program", required = false) UUID program) {
-    permissionService.canManageRequisitionTemplate();
+    permissionService.canManageRequisitionTemplate().throwExceptionIfHasErrors();
     return RequisitionTemplateDto.newInstance(
         requisitionTemplateService.getTemplateForProgram(program));
   }

--- a/src/main/java/org/openlmis/requisition/web/StatusMessageController.java
+++ b/src/main/java/org/openlmis/requisition/web/StatusMessageController.java
@@ -53,7 +53,7 @@ public class StatusMessageController extends BaseController {
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
   public List<StatusMessageDto> getAllRequisitionStatusMessages(@PathVariable("id") UUID id) {
-    permissionService.canViewRequisition(id);
+    permissionService.canViewRequisition(id).throwExceptionIfHasErrors();
     List<StatusMessage> statusMessages = statusMessageRepository.findByRequisitionId(id);
     return exportToDtos(statusMessages);
   }

--- a/src/test/java/org/openlmis/requisition/domain/RequisitionStatusTest.java
+++ b/src/test/java/org/openlmis/requisition/domain/RequisitionStatusTest.java
@@ -33,6 +33,7 @@ public class RequisitionStatusTest {
   private boolean preAuthorize;
   private boolean postSubmitted;
   private boolean submittable;
+  private boolean updatable;
 
   /**
    * Creates a new instance of RequisitionStatusTest. It is used by JUnit to create a parameterized
@@ -43,11 +44,12 @@ public class RequisitionStatusTest {
    * @param postSubmitted flag that is used to check if the given status should be postSubmitted
    */
   public RequisitionStatusTest(RequisitionStatus status, boolean preAuthorize,
-                               boolean postSubmitted, boolean submittable) {
+                               boolean postSubmitted, boolean submittable, boolean updatable) {
     this.status = status;
     this.preAuthorize = preAuthorize;
     this.postSubmitted = postSubmitted;
     this.submittable = submittable;
+    this.updatable = updatable;
   }
 
   /**
@@ -56,16 +58,16 @@ public class RequisitionStatusTest {
    * @return a collections of arrays that contain data needed to create a new instance of the test.
    */
   @Parameterized.Parameters(name = "status = {0}, preAuthorize = {1}, postSubmitted = {2}, "
-      + "submittable = {3}")
+      + "submittable = {3}, updatable = {4}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        {RequisitionStatus.INITIATED, true, false, true},
-        {RequisitionStatus.REJECTED, true, false, true},
-        {RequisitionStatus.SUBMITTED, true, true, false},
-        {RequisitionStatus.AUTHORIZED, false, true, false},
-        {RequisitionStatus.APPROVED, false, true, false},
-        {RequisitionStatus.RELEASED, false, true, false},
-        {RequisitionStatus.SKIPPED, false, false, false}
+        {RequisitionStatus.INITIATED, true, false, true, true},
+        {RequisitionStatus.REJECTED, true, false, true, true},
+        {RequisitionStatus.SUBMITTED, true, true, false, true},
+        {RequisitionStatus.AUTHORIZED, false, true, false,true},
+        {RequisitionStatus.APPROVED, false, true, false, false},
+        {RequisitionStatus.RELEASED, false, true, false, false},
+        {RequisitionStatus.SKIPPED, false, false, false, false}
     });
   }
 
@@ -82,5 +84,10 @@ public class RequisitionStatusTest {
   @Test
   public void shouldHaveCorrectValueForSubmittable() throws Exception {
     assertThat(status.isSubmittable(), is(equalTo(submittable)));
+  }
+
+  @Test
+  public void shouldHaveCorrectValueForUpdatable() throws Exception {
+    assertThat(status.isUpdatable(), is(equalTo(updatable)));
   }
 }

--- a/src/test/java/org/openlmis/requisition/errorhandling/ValidationResultTest.java
+++ b/src/test/java/org/openlmis/requisition/errorhandling/ValidationResultTest.java
@@ -1,0 +1,89 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.errorhandling;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.openlmis.requisition.exception.ContentNotFoundMessageException;
+import org.openlmis.requisition.exception.ValidationMessageException;
+import org.openlmis.requisition.exception.VersionMismatchException;
+import org.openlmis.requisition.web.PermissionMessageException;
+import org.openlmis.utils.Message;
+
+import java.util.List;
+
+public class ValidationResultTest {
+
+  @Test(expected = ValidationMessageException.class)
+  public void shouldThrowValidationMessageException() {
+    ValidationResult result = ValidationResult.failedValidation("validationFailed");
+
+    assertEquals(FailureType.VALIDATION, result.getError().getType());
+    result.throwExceptionIfHasErrors();
+  }
+
+  @Test(expected = ContentNotFoundMessageException.class)
+  public void shouldThrowContentNotFoundMesssageException() {
+    ValidationResult result = ValidationResult.notFound("notFound");
+
+    assertEquals(FailureType.NOT_FOUND, result.getError().getType());
+    result.throwExceptionIfHasErrors();
+  }
+
+  @Test(expected = PermissionMessageException.class)
+  public void shouldThrowPermissionMessageException() {
+    ValidationResult result = ValidationResult.noPermission("noPermission");
+
+    assertEquals(FailureType.NO_PERMISSION, result.getError().getType());
+    result.throwExceptionIfHasErrors();
+  }
+
+  @Test(expected = VersionMismatchException.class)
+  public void shouldThrowVersionMismatchException() {
+    ValidationResult result = ValidationResult.conflict("conflict");
+
+    assertEquals(FailureType.CONFLICT, result.getError().getType());
+    result.throwExceptionIfHasErrors();
+  }
+
+  @Test
+  public void shouldNotThrowExceptionIfHasNoErrors() {
+    ValidationResult.success().throwExceptionIfHasErrors();
+  }
+
+  @Test
+  public void shouldAddErrorsWithCorrectType() {
+    ValidationResult result = new ValidationResult();
+    result.addError(new Message("validationFailed"), FailureType.VALIDATION);
+    result.addError(new Message("validationFailedAgain"), FailureType.VALIDATION);
+    result.addError(new Message("youDontHaveAccessAnyways"), FailureType.NO_PERMISSION);
+
+    List<ValidationFailure> actual = result.gerErrors();
+    assertNotNull(actual);
+    assertEquals(3, actual.size());
+
+    assertEquals(new Message("validationFailed"), actual.get(0).getMessage());
+    assertEquals(FailureType.VALIDATION, actual.get(0).getType());
+
+    assertEquals(new Message("validationFailedAgain"), actual.get(1).getMessage());
+    assertEquals(FailureType.VALIDATION, actual.get(1).getType());
+
+    assertEquals(new Message("youDontHaveAccessAnyways"), actual.get(2).getMessage());
+    assertEquals(FailureType.NO_PERMISSION, actual.get(2).getType());
+  }
+}

--- a/src/test/java/org/openlmis/requisition/web/ReportsControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/ReportsControllerTest.java
@@ -27,6 +27,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.openlmis.requisition.domain.Requisition;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 import org.openlmis.requisition.exception.ContentNotFoundMessageException;
 import org.openlmis.requisition.exception.JasperReportViewException;
 import org.openlmis.requisition.repository.RequisitionRepository;
@@ -70,6 +71,9 @@ public class ReportsControllerTest {
   @Test(expected = ContentNotFoundMessageException.class)
   public void shouldNotPrintRequisitionIfTRequisitionDoesNotExist()
       throws JasperReportViewException {
+    //given
+    when(permissionService.canViewRequisition(any(UUID.class)))
+        .thenReturn(ValidationResult.notFound("requisition.not.found"));
     // when
     reportsController.print(mock(HttpServletRequest.class), UUID.randomUUID());
   }
@@ -84,6 +88,8 @@ public class ReportsControllerTest {
     when(requisitionRepository.findOne(any(UUID.class))).thenReturn(mock(Requisition.class));
     when(jasperReportsViewService.getRequisitionJasperReportView(
         any(Requisition.class), any(HttpServletRequest.class))).thenReturn(view);
+    when(permissionService.canViewRequisition(any(UUID.class)))
+        .thenReturn(ValidationResult.success());
 
     // when
     ModelAndView result = reportsController.print(request, UUID.randomUUID());


### PR DESCRIPTION
As a first part of contributing batch approval endpoints,
we have refactored the error handling within requisition service.
The validators can now use an instance of ValidationResult class
to signal validation outcome, rather than throwing the exception
directly. The ValidationResult class has got many helper/utils
method to ease saving errors and handling them. Users of the
ValidationResult can then choose what to do with the outcome
of the validation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/42)
<!-- Reviewable:end -->
