### PR TITLE
MW-397 Added batch approval endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ New functionality added in a backwards-compatible manner:
 
 * [OLMIS-2709](https://openlmis.atlassian.net/browse/OLMIS-2709): Changed ReferenceData facility service search endpoint to use smaller dto.
 * The /requisitions/requisitionsForConvert endpoint accepts several sortBy parameters. Data returned by the endpoint will be sorted by those parameters in order of occurrence. By defaults data will be sorted by emergency flag and program name.
+* [OLMIS-2928](https://openlmis.atlassian.net/browse/OLMIS-2928): Introduced new batch endpoints, that allow retrieval and approval of several requisitions at once. This also refactored the error handling.
 
 Bug fixes added in a backwards-compatible manner:
 * [OLMIS-2788](https://openlmis.atlassian.net/browse/OLMIS-2788): Fixed print requisition.
 * [OLMIS-2747](https://openlmis.atlassian.net/browse/OLMIS-2747): Fixed bug preventing user from being able to re-initiate a requisition after being removed, when there's already a requisition for next period.
 * [OLMIS-2871](https://openlmis.atlassian.net/browse/OLMIS-2871): The service now uses an Authorization header instead of an access_token request parameter when communicating with other services.
-* [MW-397](https://openlmis.atlassian.net/browse/MW-397): Refactored the error handling.
 * [OLMIS-2534](https://openlmis.atlassian.net/browse/OLMIS-2534): Fixed potential huge performance issue. The javers log initializer will not retrieve all domain objects at once if a repository implemenets [PagingAndSortingRepository](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/repository/PagingAndSortingRepository.html)
 
 4.0.0 / 2017-06-23

--- a/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
@@ -18,11 +18,13 @@ package org.openlmis.requisition.repository;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.openlmis.requisition.domain.RequisitionStatus.INITIATED;
 
 import com.google.common.collect.Sets;
 
+import org.assertj.core.util.Lists;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.junit.Before;
@@ -230,6 +232,19 @@ public class RequisitionRepositoryIntegrationTest
 
     // then
     assertEquals(matchingRequisitions.size(), result.size());
+  }
+
+  @Test
+  public void shouldFindRequisitionsByMultipleIds() {
+    UUID id1 = requisitions.get(0).getId();
+    UUID id2 = requisitions.get(1).getId();
+
+    List<Requisition> foundRequisitions = Lists.newArrayList(repository.findAll(
+        Lists.newArrayList(id1, id2, UUID.randomUUID())));
+    assertNotNull(foundRequisitions);
+    assertEquals(2, foundRequisitions.size());
+    assertEquals(requisitions.get(0), foundRequisitions.get(0));
+    assertEquals(requisitions.get(1), foundRequisitions.get(1));
   }
 
   @Test

--- a/src/integration-test/java/org/openlmis/requisition/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/BaseWebIntegrationTest.java
@@ -56,16 +56,16 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import guru.nidi.ramltester.RamlDefinition;
+import guru.nidi.ramltester.RamlLoaders;
+import guru.nidi.ramltester.restassured.RestAssuredClient;
+
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.UUID;
 
 import javax.annotation.PostConstruct;
-
-import guru.nidi.ramltester.RamlDefinition;
-import guru.nidi.ramltester.RamlLoaders;
-import guru.nidi.ramltester.restassured.RestAssuredClient;
 
 
 @RunWith(SpringRunner.class)
@@ -97,7 +97,7 @@ public abstract class BaseWebIntegrationTest {
   protected RestAssuredClient restAssured;
 
   @Autowired
-  private ObjectMapper objectMapper;
+  protected ObjectMapper objectMapper;
 
   @LocalServerPort
   private int serverPort;

--- a/src/integration-test/java/org/openlmis/requisition/web/BatchRequisitionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/BatchRequisitionControllerIntegrationTest.java
@@ -138,11 +138,11 @@ public class BatchRequisitionControllerIntegrationTest extends BaseWebIntegratio
         .when(requisitionVersionValidator)
         .validateRequisitionTimestamps(any(Requisition.class), any(Requisition.class));
 
-    doReturn(Lists.newArrayList())
+    doReturn(Collections.emptyList())
         .when(stockAdjustmentReasonReferenceDataService)
         .getStockAdjustmentReasonsByProgram(any(UUID.class));
 
-    doReturn(Lists.newArrayList())
+    doReturn(Collections.emptyList())
         .when(orderableReferenceDataService)
         .findByIds(anySetOf(UUID.class));
   }
@@ -270,6 +270,10 @@ public class BatchRequisitionControllerIntegrationTest extends BaseWebIntegratio
     assertThat(
         requisitionErrors.get(0).get("requisitionId").asText(),
         equalTo(requisitions.get(0).getId().toString())
+    );
+    assertThat(
+        requisitionErrors.get(0).get("errorMessage").get("messageKey").asText(),
+        equalTo(ERROR_NO_FOLLOWING_PERMISSION)
     );
 
     ArrayNode requisitionDtos = (ArrayNode) json.get("requisitionDtos");

--- a/src/integration-test/java/org/openlmis/requisition/web/BatchRequisitionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/BatchRequisitionControllerIntegrationTest.java
@@ -171,7 +171,7 @@ public class BatchRequisitionControllerIntegrationTest extends BaseWebIntegratio
         .when(permissionService).canViewRequisition(requisitions.get(0));
 
     Response response = get(RETRIEVE_ALL, requisitionIds);
-    checkErrorResponseBody(response, 200);
+    checkErrorResponseBody(response, 400);
   }
 
   // POST /api/requisitions?approveAll&id={}&id={}&id={}

--- a/src/integration-test/java/org/openlmis/requisition/web/BatchRequisitionControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/BatchRequisitionControllerIntegrationTest.java
@@ -1,0 +1,404 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.web;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anySetOf;
+import static org.mockito.Mockito.doReturn;
+import static org.openlmis.requisition.i18n.MessageKeys.ERROR_NO_FOLLOWING_PERMISSION;
+import static org.openlmis.requisition.service.PermissionService.REQUISITION_APPROVE;
+import static org.openlmis.requisition.service.PermissionService.REQUISITION_VIEW;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.jayway.restassured.response.Response;
+import com.jayway.restassured.specification.RequestSpecification;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.openlmis.requisition.domain.BaseEntity;
+import org.openlmis.requisition.domain.Requisition;
+import org.openlmis.requisition.domain.RequisitionStatus;
+import org.openlmis.requisition.dto.ApproveRequisitionDto;
+import org.openlmis.requisition.dto.BasicRequisitionTemplateDto;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.ProcessingPeriodDto;
+import org.openlmis.requisition.dto.ProgramDto;
+import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
+import org.openlmis.requisition.service.RequisitionService;
+import org.openlmis.requisition.service.RequisitionStatusProcessor;
+import org.openlmis.requisition.service.referencedata.OrderableReferenceDataService;
+import org.openlmis.requisition.service.referencedata.StockAdjustmentReasonReferenceDataService;
+import org.openlmis.requisition.service.referencedata.SupervisoryNodeReferenceDataService;
+import org.openlmis.requisition.validate.RequisitionValidator;
+import org.openlmis.requisition.validate.RequisitionVersionValidator;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.UnusedPrivateField"})
+public class BatchRequisitionControllerIntegrationTest extends BaseWebIntegrationTest {
+  private static final String RESOURCE_URL = "/api/requisitions";
+  private static final String RETRIEVE_ALL = "retrieveAll";
+  private static final String APPROVE_ALL = "approveAll";
+  private static final String SAVE_ALL = "saveAll";
+  private static final String ID = "id";
+
+  @MockBean
+  private RequisitionService requisitionService;
+
+  @MockBean
+  private RequisitionDtoBuilder requisitionDtoBuilder;
+
+  @MockBean
+  private RequisitionValidator validator;
+
+  @MockBean
+  private StockAdjustmentReasonReferenceDataService stockAdjustmentReasonReferenceDataService;
+
+  @MockBean
+  private SupervisoryNodeReferenceDataService supervisoryNodeReferenceDataService;
+
+  @MockBean
+  private OrderableReferenceDataService orderableReferenceDataService;
+
+  @MockBean
+  private RequisitionStatusProcessor requisitionStatusProcessor;
+
+  @MockBean
+  private BasicRequisitionDtoBuilder basicRequisitionDtoBuilder;
+
+  @MockBean
+  private RequisitionVersionValidator requisitionVersionValidator;
+
+  private List<Requisition> requisitions;
+  private List<ApproveRequisitionDto> approveRequisitions;
+  private List<UUID> requisitionIds;
+
+  @Before
+  public void setUp() {
+    mockUserAuthenticated();
+
+    mockRepositorySaveAnswer();
+    mockRequisitionDtoBuilderResponses();
+
+    requisitions = Lists.newArrayList(
+        generateRequisition(RequisitionStatus.AUTHORIZED),
+        generateRequisition(RequisitionStatus.AUTHORIZED),
+        generateRequisition(RequisitionStatus.AUTHORIZED)
+    );
+
+    requisitionIds = requisitions
+        .stream()
+        .map(BaseEntity::getId)
+        .collect(Collectors.toList());
+
+    approveRequisitions = requisitions
+        .stream()
+        .map(requisition -> requisitionDtoBuilder.build(requisition))
+        .map(ApproveRequisitionDto::new)
+        .collect(Collectors.toList());
+
+    doReturn(requisitions)
+        .when(requisitionRepository).findAll(requisitionIds);
+
+    doReturn(ValidationResult.success())
+        .when(requisitionVersionValidator)
+        .validateRequisitionTimestamps(any(Requisition.class), any(Requisition.class));
+
+    doReturn(Lists.newArrayList())
+        .when(stockAdjustmentReasonReferenceDataService)
+        .getStockAdjustmentReasonsByProgram(any(UUID.class));
+
+    doReturn(Lists.newArrayList())
+        .when(orderableReferenceDataService)
+        .findByIds(anySetOf(UUID.class));
+  }
+
+  // GET /api/requisitions?retrieveAll&id={}&id={}&id={}
+
+  @Test
+  public void shouldRetrieveAll() throws Exception {
+    requisitions.forEach(requisition ->
+        doReturn(ValidationResult.success())
+            .when(permissionService).canViewRequisition(requisition)
+    );
+
+    Response response = get(RETRIEVE_ALL, requisitionIds);
+    checkResponseBody(response);
+  }
+
+  @Test
+  public void shouldHaveErrorIfUserHasNoRightToView() throws Exception {
+    requisitions.forEach(requisition ->
+        doReturn(ValidationResult.success())
+            .when(permissionService).canViewRequisition(requisition)
+    );
+
+    doReturn(ValidationResult.noPermission(ERROR_NO_FOLLOWING_PERMISSION, REQUISITION_VIEW))
+        .when(permissionService).canViewRequisition(requisitions.get(0));
+
+    Response response = get(RETRIEVE_ALL, requisitionIds);
+    checkErrorResponseBody(response, 200);
+  }
+
+  // POST /api/requisitions?approveAll&id={}&id={}&id={}
+
+  @Test
+  public void shouldApproveAll() throws Exception {
+    UUID userId = authenticationHelper.getCurrentUser().getId();
+
+    requisitions.forEach(requisition ->
+        doReturn(ValidationResult.success())
+            .when(requisitionService)
+            .validateCanApproveRequisition(requisition, requisition.getId(), userId)
+    );
+
+    Response response = post(APPROVE_ALL, requisitionIds);
+    checkResponseBody(response);
+  }
+
+  @Test
+  public void shouldHaveErrorIfUserHasNoRightToApprove() throws Exception {
+    UUID userId = authenticationHelper.getCurrentUser().getId();
+
+    requisitions.forEach(requisition ->
+        doReturn(ValidationResult.success())
+            .when(requisitionService)
+            .validateCanApproveRequisition(requisition, requisition.getId(), userId)
+    );
+
+    doReturn(ValidationResult.noPermission(ERROR_NO_FOLLOWING_PERMISSION, REQUISITION_APPROVE))
+        .when(requisitionService)
+        .validateCanApproveRequisition(requisitions.get(0), requisitions.get(0).getId(), userId);
+
+    Response response = post(APPROVE_ALL, requisitionIds);
+    checkErrorResponseBody(response, 400);
+  }
+
+  // PUT /api/requisitions?saveAll
+
+  @Test
+  public void shouldSaveAll() throws Exception {
+    requisitions.forEach(requisition ->
+        doReturn(ValidationResult.success())
+            .when(requisitionService)
+            .validateCanSaveRequisition(requisition.getId())
+    );
+
+    Response response = put(SAVE_ALL, approveRequisitions);
+    checkResponseBody(response);
+  }
+
+  @Test
+  public void shouldHaveErrorIfUserHasNoRightToUpdate() throws Exception {
+    requisitions.forEach(requisition ->
+        doReturn(ValidationResult.success())
+            .when(requisitionService)
+            .validateCanSaveRequisition(requisition.getId())
+    );
+
+    doReturn(ValidationResult.noPermission(ERROR_NO_FOLLOWING_PERMISSION, REQUISITION_APPROVE))
+        .when(requisitionService).validateCanSaveRequisition(requisitions.get(0).getId());
+
+    Response response = put(SAVE_ALL, approveRequisitions);
+    checkErrorResponseBody(response, 400);
+  }
+
+  private void checkResponseBody(Response response) throws IOException {
+    String jsonString = response
+        .then()
+        .statusCode(200)
+        .extract()
+        .asString();
+
+    JsonNode json = objectMapper.readTree(jsonString);
+    ArrayNode requisitionErrors = (ArrayNode) json.get("requisitionErrors");
+
+    assertThat(requisitionErrors.size(), equalTo(0));
+
+    ArrayNode requisitionDtos = (ArrayNode) json.get("requisitionDtos");
+
+    List<UUID> retrieved = getIds(requisitionDtos);
+
+    assertThat(retrieved, hasItems(requisitionIds.toArray(new UUID[requisitionIds.size()])));
+  }
+
+  private void checkErrorResponseBody(Response response, int statusCode) throws IOException {
+    String jsonString = response
+        .then()
+        .statusCode(statusCode)
+        .extract()
+        .asString();
+
+    JsonNode json = objectMapper.readTree(jsonString);
+    ArrayNode requisitionErrors = (ArrayNode) json.get("requisitionErrors");
+
+    assertThat(requisitionErrors.size(), equalTo(1));
+    assertThat(
+        requisitionErrors.get(0).get("requisitionId").asText(),
+        equalTo(requisitions.get(0).getId().toString())
+    );
+
+    ArrayNode requisitionDtos = (ArrayNode) json.get("requisitionDtos");
+
+    List<UUID> retrieved = getIds(requisitionDtos);
+
+    assertThat(retrieved, allOf(
+        not(hasItem(requisitions.get(0).getId())),
+        hasItem(requisitions.get(1).getId()),
+        hasItem(requisitions.get(2).getId())
+    ));
+  }
+
+  private List<UUID> getIds(ArrayNode requisitionDtos) {
+    List<UUID> result = Lists.newArrayList();
+    requisitionDtos.forEach(node -> result.add(UUID.fromString(node.get("id").asText())));
+
+    return result;
+  }
+
+  private Response put(String param, List<ApproveRequisitionDto> body) {
+    return startRequest(param)
+        .body(body)
+        .put(RESOURCE_URL);
+  }
+
+  private Response get(String param, List<UUID> ids) {
+    RequestSpecification specification = startRequest(param);
+
+    for (UUID id : ids) {
+      specification = specification.queryParam(ID, id);
+    }
+
+    return specification.get(RESOURCE_URL);
+  }
+
+  private Response post(String param, List<UUID> ids) {
+    RequestSpecification specification = startRequest(param);
+
+    for (UUID id : ids) {
+      specification = specification.queryParam(ID, id);
+    }
+
+    return specification.post(RESOURCE_URL);
+  }
+
+  private RequestSpecification startRequest(String param) {
+    return restAssured
+        .given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .queryParam(param, "");
+  }
+
+  private void mockRepositorySaveAnswer() {
+    given(requisitionRepository.save(any(Requisition.class))).willAnswer(new SaveAnswer<>());
+  }
+
+  private void mockRequisitionDtoBuilderResponses() {
+    given(requisitionDtoBuilder.build(any(Requisition.class)))
+        .willAnswer(new BuildRequisitionDtoAnswer());
+    given(requisitionDtoBuilder
+        .build(any(Requisition.class), any(FacilityDto.class), any(ProgramDto.class)))
+        .willAnswer(new BuildRequisitionDtoAnswer());
+    given(requisitionDtoBuilder.build(anyListOf(Requisition.class)))
+        .willAnswer(new BuildListOfRequisitionDtosAnswer());
+  }
+
+  protected static class BuildRequisitionDtoAnswer implements Answer<RequisitionDto> {
+
+    @Override
+    public RequisitionDto answer(InvocationOnMock invocation) throws Throwable {
+      Requisition requisition = (Requisition) invocation.getArguments()[0];
+
+      if (null == requisition) {
+        return null;
+      }
+
+      return export(requisition);
+    }
+
+    public static RequisitionDto export(Requisition requisition) {
+      RequisitionDto dto = new RequisitionDto();
+      requisition.export(dto);
+
+      dto.setTemplate(BasicRequisitionTemplateDto.newInstance(requisition.getTemplate()));
+      dto.setRequisitionLineItems(Collections.emptyList());
+
+      FacilityDto facility = null;
+      if (requisition.getFacilityId() != null) {
+        facility = new FacilityDto();
+        facility.setId(requisition.getFacilityId());
+      }
+
+      ProgramDto program = null;
+      if (requisition.getProgramId() != null) {
+        program = new ProgramDto();
+        program.setId(requisition.getProgramId());
+      }
+
+      ProcessingPeriodDto period = null;
+      if (requisition.getProcessingPeriodId() != null) {
+        period = new ProcessingPeriodDto();
+        period.setId(requisition.getProcessingPeriodId());
+      }
+
+      dto.setProcessingPeriod(period);
+      dto.setFacility(facility);
+      dto.setProgram(program);
+
+      return dto;
+    }
+  }
+
+  protected static class BuildListOfRequisitionDtosAnswer implements Answer<List<RequisitionDto>> {
+
+    @Override
+    public List<RequisitionDto> answer(InvocationOnMock invocation) throws Throwable {
+      Collection<Requisition> collection = (Collection) invocation.getArguments()[0];
+
+      if (null == collection) {
+        return null;
+      }
+
+      return collection
+          .stream()
+          .map(BatchRequisitionControllerIntegrationTest.BuildRequisitionDtoAnswer::export)
+          .collect(Collectors.toList());
+    }
+  }
+
+}

--- a/src/main/java/org/openlmis/requisition/dto/ApproveRequisitionDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/ApproveRequisitionDto.java
@@ -1,0 +1,76 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.openlmis.requisition.domain.RequisitionStatus;
+import org.openlmis.requisition.domain.StatusLogEntry;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApproveRequisitionDto {
+  private UUID id;
+  private Boolean emergency;
+  private RequisitionStatus status;
+  private ZonedDateTime modifiedDate;
+
+  private Map<String, StatusLogEntry> statusChanges = new HashMap<>();
+
+  @JsonSerialize(as = BasicProcessingPeriodDto.class)
+  private BasicProcessingPeriodDto processingPeriod;
+
+  @JsonSerialize(as = MinimalFacilityDto.class)
+  private MinimalFacilityDto facility;
+
+  @JsonSerialize(as = BasicProgramDto.class)
+  private BasicProgramDto program;
+  private List<ApproveRequisitionLineItemDto> requisitionLineItems;
+
+  /**
+   * Creates instance with data from original requisition.
+   */
+  public ApproveRequisitionDto(RequisitionDto requisition) {
+    this.id = requisition.getId();
+    this.emergency = requisition.getEmergency();
+    this.status = requisition.getStatus();
+    this.modifiedDate = requisition.getModifiedDate();
+    this.statusChanges = requisition.getStatusChanges();
+    this.processingPeriod = requisition.getProcessingPeriod();
+    this.facility = requisition.getFacility();
+    this.program = requisition.getProgram();
+    this.requisitionLineItems = requisition
+        .getRequisitionLineItems()
+        .stream()
+        .map(ApproveRequisitionLineItemDto::new)
+        .collect(Collectors.toList());
+  }
+
+}

--- a/src/main/java/org/openlmis/requisition/dto/ApproveRequisitionLineItemDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/ApproveRequisitionLineItemDto.java
@@ -1,0 +1,67 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.joda.money.Money;
+import org.openlmis.requisition.domain.RequisitionLineItem;
+import org.openlmis.utils.MoneyDeserializer;
+import org.openlmis.utils.MoneySerializer;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApproveRequisitionLineItemDto {
+  private UUID id;
+
+  @JsonSerialize(as = BasicOrderableDto.class)
+  private BasicOrderableDto orderable;
+
+  private Integer approvedQuantity;
+
+  @JsonSerialize(using = MoneySerializer.class)
+  @JsonDeserialize(using = MoneyDeserializer.class)
+  private Money pricePerPack;
+
+  @JsonSerialize(using = MoneySerializer.class)
+  @JsonDeserialize(using = MoneyDeserializer.class)
+  private Money totalCost;
+
+  private Boolean skipped;
+
+  /**
+   * Creates instance with data from original requisition line item.
+   */
+  public ApproveRequisitionLineItemDto(RequisitionLineItem.Importer requisitionLineItem) {
+    this.id = requisitionLineItem.getId();
+    this.orderable = requisitionLineItem.getOrderable();
+    this.approvedQuantity = requisitionLineItem.getApprovedQuantity();
+    this.pricePerPack = requisitionLineItem.getPricePerPack();
+    this.totalCost = requisitionLineItem.getTotalCost();
+    this.skipped = requisitionLineItem.getSkipped();
+  }
+
+}

--- a/src/main/java/org/openlmis/requisition/dto/BasicOrderableDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/BasicOrderableDto.java
@@ -16,46 +16,47 @@
 package org.openlmis.requisition.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.Set;
 import java.util.UUID;
 
 @Getter
 @Setter
-@NoArgsConstructor
 @AllArgsConstructor
-public class OrderableDto extends BasicOrderableDto {
-
-  private Set<ProgramOrderableDto> programs;
-  private DispensableDto dispensable;
-
-  @Builder
-  private OrderableDto(UUID id, String productCode, String fullProductName, long netContent,
-                       long packRoundingThreshold, boolean roundToZero,
-                       Set<ProgramOrderableDto> programs, DispensableDto dispensable) {
-    super(id, productCode, fullProductName, netContent, packRoundingThreshold, roundToZero);
-    this.programs = programs;
-    this.dispensable = dispensable;
-  }
+@NoArgsConstructor
+public class BasicOrderableDto {
+  private UUID id;
+  private String productCode;
+  private String fullProductName;
+  private long netContent;
+  private long packRoundingThreshold;
+  private boolean roundToZero;
 
   /**
-   * Find ProgramOrderableDto in programs using programId.
+   * Returns the number of packs to order. For this Orderable given a desired number of
+   * dispensing units, will return the number of packs that should be ordered.
    *
-   * @param programId programId
-   * @return product
+   * @param dispensingUnits # of dispensing units we'd like to order for
+   * @return the number of packs that should be ordered.
    */
-  public ProgramOrderableDto findProgramOrderableDto(UUID programId) {
-    if (programs != null) {
-      for (ProgramOrderableDto programOrderableDto : programs) {
-        if (programOrderableDto.getProgramId().equals(programId)) {
-          return programOrderableDto;
-        }
-      }
+  public long packsToOrder(long dispensingUnits) {
+    if (dispensingUnits <= 0 || netContent == 0) {
+      return 0;
     }
-    return null;
+
+    long packsToOrder = dispensingUnits / netContent;
+    long remainderQuantity = dispensingUnits % netContent;
+
+    if (remainderQuantity > 0 && remainderQuantity > packRoundingThreshold) {
+      packsToOrder += 1;
+    }
+
+    if (packsToOrder == 0 && !roundToZero) {
+      packsToOrder = 1;
+    }
+
+    return packsToOrder;
   }
 }

--- a/src/main/java/org/openlmis/requisition/dto/RequisitionErrorMessage.java
+++ b/src/main/java/org/openlmis/requisition/dto/RequisitionErrorMessage.java
@@ -13,7 +13,7 @@
  * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
  */
 
-package org.openlmis.requisition.errorhandling;
+package org.openlmis.requisition.dto;
 
 import org.openlmis.utils.Message;
 
@@ -21,11 +21,26 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.Map;
+import java.util.UUID;
 
-@AllArgsConstructor
+/**
+ * General and field error messages linked with a specific requisition.
+ */
 @Getter
-public class ValidationFailure {
-  private Message message;
+@AllArgsConstructor
+public class RequisitionErrorMessage {
+
+  private UUID requisitionId;
+  private Message.LocalizedMessage errorMessage;
   private Map<String, String> fieldErrors;
-  private FailureType type;
+
+  public RequisitionErrorMessage(UUID requisitionId, Message.LocalizedMessage message) {
+    this.requisitionId = requisitionId;
+    this.errorMessage = message;
+  }
+
+  public RequisitionErrorMessage(UUID requisitionId, Map<String, String> fieldErrors) {
+    this.requisitionId = requisitionId;
+    this.fieldErrors = fieldErrors;
+  }
 }

--- a/src/main/java/org/openlmis/requisition/dto/RequisitionsProcessingStatusDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/RequisitionsProcessingStatusDto.java
@@ -50,7 +50,7 @@ public class RequisitionsProcessingStatusDto {
   }
 
   /**
-   * Removes skipped products but only if those products are skipped in all requisitions.
+   * Removes skipped line items if they are skipped in all requisitions.
    */
   public void removeSkippedProducts() {
     // all requisition line items
@@ -68,7 +68,7 @@ public class RequisitionsProcessingStatusDto {
         .map(BasicOrderableDto::getId)
         .collect(Collectors.toSet());
 
-    // if the given product is not skipped in any requisition, it will not be removed
+    // if the given line item is not skipped in any requisition, it will not be removed
     // because it will not be present on the list.
     requisitionLineItems
         .stream()

--- a/src/main/java/org/openlmis/requisition/dto/RequisitionsProcessingStatusDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/RequisitionsProcessingStatusDto.java
@@ -1,0 +1,99 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.dto;
+
+import org.apache.commons.lang3.BooleanUtils;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the results of a batch processing of requisitions.
+ */
+@Getter
+public class RequisitionsProcessingStatusDto {
+
+  private List<ApproveRequisitionDto> requisitionDtos;
+  private List<RequisitionErrorMessage> requisitionErrors;
+
+  public RequisitionsProcessingStatusDto() {
+    this.requisitionDtos = new ArrayList<>();
+    this.requisitionErrors = new ArrayList<>();
+  }
+
+  public void addProcessedRequisition(ApproveRequisitionDto requisitionDto) {
+    requisitionDtos.add(requisitionDto);
+  }
+
+  public void addProcessingError(RequisitionErrorMessage errorMessage) {
+    this.requisitionErrors.add(errorMessage);
+  }
+
+  /**
+   * Removes skipped products but only if those products are skipped in all requisitions.
+   */
+  public void removeSkippedProducts() {
+    // all requisition line items
+    List<ApproveRequisitionLineItemDto> requisitionLineItems = requisitionDtos
+        .stream()
+        .map(ApproveRequisitionDto::getRequisitionLineItems)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+
+    // all products. This list contains products that would be removed because all selected
+    // requisitions skipped those products.
+    Set<UUID> products = requisitionLineItems
+        .stream()
+        .map(ApproveRequisitionLineItemDto::getOrderable)
+        .map(BasicOrderableDto::getId)
+        .collect(Collectors.toSet());
+
+    // if the given product is not skipped in any requisition, it will not be removed
+    // because it will not be present on the list.
+    requisitionLineItems
+        .stream()
+        .filter(line -> BooleanUtils.isFalse(line.getSkipped()))
+        .map(ApproveRequisitionLineItemDto::getOrderable)
+        .map(BasicOrderableDto::getId)
+        .forEach(products::remove);
+
+    // find those requisition line items that contain skipped (in all requisitions) product
+    // and remove it.
+    for (ApproveRequisitionDto requisition : requisitionDtos) {
+      Iterator<ApproveRequisitionLineItemDto> iterator = requisition
+          .getRequisitionLineItems()
+          .iterator();
+
+      while (iterator.hasNext()) {
+        ApproveRequisitionLineItemDto line = iterator.next();
+        BasicOrderableDto orderable = line.getOrderable();
+        UUID id = orderable.getId();
+
+        if (products.contains(id)) {
+          iterator.remove();
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/java/org/openlmis/requisition/errorhandling/FailureType.java
+++ b/src/main/java/org/openlmis/requisition/errorhandling/FailureType.java
@@ -19,5 +19,6 @@ public enum FailureType {
   VALIDATION,
   NOT_FOUND,
   NO_PERMISSION,
-  CONFLICT
+  CONFLICT,
+  FIELD_VALIDATION
 }

--- a/src/main/java/org/openlmis/requisition/service/PermissionService.java
+++ b/src/main/java/org/openlmis/requisition/service/PermissionService.java
@@ -175,10 +175,11 @@ public class PermissionService {
 
   /**
    * Checks if current user has permission to view a requisition.
-   * @return true if user has got the necessary rights to view given requisition; false otherwise
+   *
+   * @return ValidationResult containing info about the result of this check
    */
-  public boolean canViewRequisition(Requisition requisition) {
-    return hasPermission(REQUISITION_VIEW, requisition.getProgramId(),
+  public ValidationResult canViewRequisition(Requisition requisition) {
+    return checkPermission(REQUISITION_VIEW, requisition.getProgramId(),
         requisition.getFacilityId(), null);
   }
 

--- a/src/main/java/org/openlmis/requisition/service/RequisitionSecurityService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionSecurityService.java
@@ -50,7 +50,7 @@ public class RequisitionSecurityService {
       Boolean accessible = getCachedRight(verified, requisition);
 
       if (accessible == null) {
-        accessible = permissionService.canViewRequisition(requisition);
+        accessible = permissionService.canViewRequisition(requisition).isSuccess();
         addCachedRight(verified, requisition, accessible);
       }
 

--- a/src/main/java/org/openlmis/requisition/service/RequisitionService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionService.java
@@ -16,13 +16,11 @@
 package org.openlmis.requisition.service;
 
 import static java.util.Objects.isNull;
-import static org.apache.commons.lang3.BooleanUtils.isNotTrue;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.openlmis.requisition.domain.RequisitionStatus.APPROVED;
 import static org.openlmis.requisition.domain.RequisitionStatus.SKIPPED;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_CANNOT_UPDATE_WITH_STATUS;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_DELETE_FAILED_WRONG_STATUS;
-import static org.openlmis.requisition.i18n.MessageKeys.ERROR_ID_MISMATCH;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_MUST_HAVE_SUPPLYING_FACILITY;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_PROGRAM_DOES_NOT_ALLOW_SKIP;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_PROGRAM_ID_CANNOT_BE_NULL;
@@ -53,7 +51,6 @@ import org.openlmis.requisition.dto.ProcessingPeriodDto;
 import org.openlmis.requisition.dto.ProgramDto;
 import org.openlmis.requisition.dto.ProgramOrderableDto;
 import org.openlmis.requisition.dto.ProofOfDeliveryDto;
-import org.openlmis.requisition.dto.RequisitionDto;
 import org.openlmis.requisition.dto.RequisitionWithSupplyingDepotsDto;
 import org.openlmis.requisition.dto.RightDto;
 import org.openlmis.requisition.dto.UserDto;
@@ -454,20 +451,13 @@ public class RequisitionService {
    * It makes sure that the user has got rights to save the requisition, that the requisition
    * exists and that it has got correct status to be eligible for saving.
    *
-   * @param requisitionDto the requisition DTO to verify
    * @param requisitionId the UUID for which the request was made
    * @return ValidationResult instance containing the outcome of this validation
    */
-  public ValidationResult validateCanSaveRequisition(RequisitionDto requisitionDto,
-                                                     UUID requisitionId) {
+  public ValidationResult validateCanSaveRequisition(UUID requisitionId) {
     ValidationResult permissionCheck = permissionService.canUpdateRequisition(requisitionId);
     if (permissionCheck.hasErrors()) {
       return permissionCheck;
-    }
-
-    if (isNotTrue(isNull(requisitionDto.getId()))
-        && isNotTrue(requisitionId.equals(requisitionDto.getId()))) {
-      return ValidationResult.failedValidation(ERROR_ID_MISMATCH);
     }
 
     Requisition requisitionToUpdate = requisitionRepository.findOne(requisitionId);

--- a/src/main/java/org/openlmis/requisition/validate/AbstractRequisitionValidator.java
+++ b/src/main/java/org/openlmis/requisition/validate/AbstractRequisitionValidator.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 
 @Component
-abstract class AbstractRequisitionValidator extends BaseValidator {
+public abstract class AbstractRequisitionValidator extends BaseValidator {
   static final String REQUISITION_LINE_ITEMS = "requisitionLineItems";
 
   public boolean supports(Class<?> clazz) {

--- a/src/main/java/org/openlmis/requisition/web/BaseRequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/BaseRequisitionController.java
@@ -1,0 +1,162 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.web;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.openlmis.requisition.domain.Requisition;
+import org.openlmis.requisition.domain.RequisitionLineItem;
+import org.openlmis.requisition.domain.StatusMessage;
+import org.openlmis.requisition.dto.BasicRequisitionDto;
+import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.dto.SupervisoryNodeDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
+import org.openlmis.requisition.repository.RequisitionRepository;
+import org.openlmis.requisition.repository.StatusMessageRepository;
+import org.openlmis.requisition.service.PermissionService;
+import org.openlmis.requisition.service.RequisitionService;
+import org.openlmis.requisition.service.RequisitionStatusProcessor;
+import org.openlmis.requisition.service.referencedata.OrderableReferenceDataService;
+import org.openlmis.requisition.service.referencedata.StockAdjustmentReasonReferenceDataService;
+import org.openlmis.requisition.service.referencedata.SupervisoryNodeReferenceDataService;
+import org.openlmis.requisition.validate.AbstractRequisitionValidator;
+import org.openlmis.requisition.validate.DraftRequisitionValidator;
+import org.openlmis.requisition.validate.RequisitionValidator;
+import org.openlmis.requisition.validate.RequisitionVersionValidator;
+import org.openlmis.utils.AuthenticationHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindingResult;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public abstract class BaseRequisitionController extends BaseController {
+
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+  protected static final String REQUISITION = "requisition";
+
+  @Autowired
+  protected RequisitionService requisitionService;
+
+  @Autowired
+  protected RequisitionRepository requisitionRepository;
+
+  @Autowired
+  protected RequisitionDtoBuilder requisitionDtoBuilder;
+
+  @Autowired
+  protected PermissionService permissionService;
+
+  @Autowired
+  protected AuthenticationHelper authenticationHelper;
+
+  @Autowired
+  protected OrderableReferenceDataService orderableReferenceDataService;
+
+  @Autowired
+  protected StatusMessageRepository statusMessageRepository;
+
+  @Autowired
+  protected BasicRequisitionDtoBuilder basicRequisitionDtoBuilder;
+
+  @Autowired
+  protected StockAdjustmentReasonReferenceDataService stockAdjustmentReasonReferenceDataService;
+
+  @Autowired
+  protected SupervisoryNodeReferenceDataService supervisoryNodeReferenceDataService;
+
+  @Autowired
+  protected RequisitionValidator validator;
+
+  @Autowired
+  protected DraftRequisitionValidator draftValidator;
+
+  @Autowired
+  protected RequisitionVersionValidator requisitionVersionValidator;
+
+  @Autowired
+  protected RequisitionStatusProcessor requisitionStatusProcessor;
+
+
+  protected ValidationResult validateFields(AbstractRequisitionValidator validator,
+                                            Requisition requisition) {
+    BindingResult bindingResult = new BeanPropertyBindingResult(requisition, REQUISITION);
+    validator.validate(requisition, bindingResult);
+
+    if (bindingResult.hasErrors()) {
+      logger.warn("Validation for requisition failed: {}", getErrors(bindingResult));
+      return ValidationResult.fieldErrors(getErrors(bindingResult));
+    }
+
+    return ValidationResult.success();
+  }
+
+  protected RequisitionDto doUpdate(Requisition requisitionToUpdate, Requisition requisition) {
+    requisitionToUpdate.updateFrom(requisition,
+        stockAdjustmentReasonReferenceDataService.getStockAdjustmentReasonsByProgram(
+            requisitionToUpdate.getProgramId()), orderableReferenceDataService.findByIds(
+            getLineItemOrderableIds(requisition)));
+
+    requisitionToUpdate = requisitionRepository.save(requisitionToUpdate);
+
+    logger.debug("Saved requisition with id: " + requisitionToUpdate.getId());
+    return requisitionDtoBuilder.build(requisitionToUpdate);
+  }
+
+  protected BasicRequisitionDto doApprove(Requisition requisition, UUID userId) {
+    SupervisoryNodeDto supervisoryNodeDto =
+        supervisoryNodeReferenceDataService.findOne(requisition.getSupervisoryNodeId());
+
+    UUID parentNodeId = null;
+    if (supervisoryNodeDto != null) {
+      SupervisoryNodeDto parentNode = supervisoryNodeDto.getParentNode();
+      if (parentNode != null) {
+        parentNodeId = parentNode.getId();
+      }
+    }
+
+    requisition.approve(parentNodeId, orderableReferenceDataService.findByIds(
+        getLineItemOrderableIds(requisition)), userId);
+
+    saveStatusMessage(requisition);
+
+    requisitionRepository.save(requisition);
+    requisitionStatusProcessor.statusChange(requisition);
+    logger.debug("Requisition with id " + requisition.getId() + " approved");
+    return basicRequisitionDtoBuilder.build(requisition);
+  }
+
+  protected void saveStatusMessage(Requisition requisition) {
+    if (isNotBlank(requisition.getDraftStatusMessage())) {
+      StatusMessage newStatusMessage = StatusMessage.newStatusMessage(requisition,
+          authenticationHelper.getCurrentUser().getId(),
+          authenticationHelper.getCurrentUser().getFirstName(),
+          authenticationHelper.getCurrentUser().getLastName(),
+          requisition.getDraftStatusMessage());
+      statusMessageRepository.save(newStatusMessage);
+      requisition.setDraftStatusMessage("");
+    }
+  }
+
+  protected Set<UUID> getLineItemOrderableIds(Requisition requisition) {
+    return requisition.getRequisitionLineItems().stream().map(
+        RequisitionLineItem::getOrderableId).collect(Collectors.toSet());
+  }
+}

--- a/src/main/java/org/openlmis/requisition/web/BatchRequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/BatchRequisitionController.java
@@ -1,0 +1,218 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.web;
+
+import static org.apache.commons.lang3.BooleanUtils.isFalse;
+
+import com.google.common.collect.Lists;
+
+import org.apache.commons.beanutils.PropertyUtils;
+import org.openlmis.requisition.domain.Requisition;
+import org.openlmis.requisition.domain.RequisitionBuilder;
+import org.openlmis.requisition.domain.RequisitionLineItem;
+import org.openlmis.requisition.domain.RequisitionTemplateColumn;
+import org.openlmis.requisition.domain.SourceType;
+import org.openlmis.requisition.dto.ApproveRequisitionDto;
+import org.openlmis.requisition.dto.ApproveRequisitionLineItemDto;
+import org.openlmis.requisition.dto.RequisitionErrorMessage;
+import org.openlmis.requisition.dto.RequisitionsProcessingStatusDto;
+import org.openlmis.requisition.errorhandling.ValidationFailure;
+import org.openlmis.requisition.errorhandling.ValidationResult;
+import org.openlmis.requisition.i18n.MessageService;
+import org.openlmis.utils.Message;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Controller
+public class BatchRequisitionController extends BaseRequisitionController {
+
+  @Autowired
+  private MessageService messageService;
+
+  /**
+   * Attempts to retrieve requisitions with the provided UUIDs.
+   */
+  @RequestMapping(value = "/requisitions", params = "retrieveAll", method = RequestMethod.GET)
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public RequisitionsProcessingStatusDto retrieveAll(@RequestParam(value = "id") List<UUID> uuids) {
+    List<Requisition> requisitions = Lists.newArrayList(requisitionRepository.findAll(uuids));
+
+    RequisitionsProcessingStatusDto processingStatus = new RequisitionsProcessingStatusDto();
+
+    for (Requisition requisition : requisitions) {
+      ValidationResult accessCheck = permissionService.canViewRequisition(requisition);
+      if (accessCheck.hasErrors()) {
+        processingStatus.addProcessingError(new RequisitionErrorMessage(requisition.getId(),
+                localizeMessage(accessCheck.getError().getMessage())));
+      } else {
+        processingStatus.addProcessedRequisition(
+            new ApproveRequisitionDto(requisitionDtoBuilder.build(requisition)));
+      }
+    }
+
+    processingStatus.removeSkippedProducts();
+    return processingStatus;
+  }
+
+  /**
+   * Attempts to approve requisitions with the provided UUIDs.
+   */
+  @RequestMapping(value = "/requisitions", params = "approveAll", method = RequestMethod.POST)
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public ResponseEntity<RequisitionsProcessingStatusDto> approve(
+      @RequestParam(value = "id") List<UUID> uuids) {
+
+    RequisitionsProcessingStatusDto processingStatus = new RequisitionsProcessingStatusDto();
+    UUID userId = authenticationHelper.getCurrentUser().getId();
+
+    for (UUID requisitionId : uuids) {
+      Requisition requisition = requisitionRepository.findOne(requisitionId);
+
+      ValidationResult validationResult =
+          requisitionService.validateCanApproveRequisition(requisition, requisitionId, userId);
+      if (addValidationErrors(processingStatus, validationResult, requisitionId)) {
+        continue;
+      }
+
+      validationResult = validateFields(validator, requisition);
+      if (addValidationErrors(processingStatus, validationResult, requisitionId)) {
+        continue;
+      }
+
+      doApprove(requisition, userId);
+      processingStatus.addProcessedRequisition(
+          new ApproveRequisitionDto(requisitionDtoBuilder.build(requisition)));
+    }
+
+    return new ResponseEntity<>(processingStatus, processingStatus.getRequisitionErrors().isEmpty()
+        ? HttpStatus.OK : HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * Attempts to approve requisitions with the provided UUIDs.
+   */
+  @RequestMapping(value = "/requisitions", params = "saveAll", method = RequestMethod.PUT)
+  @ResponseStatus(HttpStatus.OK)
+  @ResponseBody
+  public ResponseEntity<RequisitionsProcessingStatusDto> update(
+      @RequestBody List<ApproveRequisitionDto> dtos) {
+
+    RequisitionsProcessingStatusDto processingStatus = new RequisitionsProcessingStatusDto();
+
+    for (ApproveRequisitionDto dto : dtos) {
+      ValidationResult result = requisitionService.validateCanSaveRequisition(dto.getId());
+      if (addValidationErrors(processingStatus, result, dto.getId())) {
+        continue;
+      }
+
+      Requisition requisitionToUpdate = requisitionRepository.findOne(dto.getId());
+      Requisition requisition = buildRequisition(dto, requisitionToUpdate);
+
+      result = requisitionVersionValidator.validateRequisitionTimestamps(
+          requisition, requisitionToUpdate);
+      result.addValidationResult(validateFields(draftValidator, requisition));
+
+      if (addValidationErrors(processingStatus, result, dto.getId())) {
+        continue;
+      }
+
+      processingStatus.addProcessedRequisition(
+            new ApproveRequisitionDto(doUpdate(requisitionToUpdate, requisition)));
+    }
+
+    processingStatus.removeSkippedProducts();
+    return new ResponseEntity<>(processingStatus, processingStatus.getRequisitionErrors().isEmpty()
+        ? HttpStatus.OK : HttpStatus.BAD_REQUEST);
+  }
+
+  private Requisition buildRequisition(ApproveRequisitionDto dto, Requisition requisitionToUpdate) {
+    Requisition requisition = RequisitionBuilder.newRequisition(
+        requisitionDtoBuilder.build(requisitionToUpdate),
+        requisitionToUpdate.getTemplate(), requisitionToUpdate.getProgramId(),
+        requisitionToUpdate.getStatus());
+    requisition.setTemplate(requisitionToUpdate.getTemplate());
+    requisition.setId(requisitionToUpdate.getId());
+    return updateOne(dto, requisition);
+  }
+
+  private Requisition updateOne(ApproveRequisitionDto dto, Requisition requisition) {
+    for (ApproveRequisitionLineItemDto line : dto.getRequisitionLineItems()) {
+      requisition
+          .getRequisitionLineItems()
+          .stream()
+          .filter(original -> Objects.equals(original.getId(), line.getId()))
+          .findFirst()
+          .ifPresent(original -> {
+            original.setApprovedQuantity(line.getApprovedQuantity());
+          });
+    }
+    requisition.setModifiedDate(dto.getModifiedDate());
+    nullCalculatedFields(requisition);
+    return requisition;
+  }
+
+  private boolean addValidationErrors(RequisitionsProcessingStatusDto processingStatus,
+                                      ValidationResult validationResult, UUID id) {
+    if (validationResult.hasErrors()) {
+      for (ValidationFailure failure : validationResult.gerErrors()) {
+        processingStatus.addProcessingError(
+            new RequisitionErrorMessage(id, localizeMessage(failure.getMessage()),
+                failure.getFieldErrors()));
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+
+  private void nullCalculatedFields(Requisition requisition) {
+    for (RequisitionLineItem lineItem : requisition.getRequisitionLineItems()) {
+      for (RequisitionTemplateColumn column : requisition.getTemplate().getColumnsMap().values()) {
+        if (isFalse(column.getIsDisplayed()) || column.getSource() == SourceType.CALCULATED) {
+          String field = column.getName();
+
+          try {
+            PropertyUtils.setSimpleProperty(lineItem, field, null);
+          } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException exp) {
+            throw new IllegalArgumentException(
+                "Could not set null value for property >" + field + "< in line item", exp
+            );
+          }
+        }
+      }
+    }
+  }
+
+  private Message.LocalizedMessage localizeMessage(Message message) {
+    return message == null ? null : messageService.localize(message);
+  }
+}

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -56,7 +56,7 @@ schemas:
           "description": "A single requisitionDto for batch approval",
           "properties": {
               "id": { "type": "string", "title": "id" },
-              "modifiedDate": {"type": "array", "title": "modifiedDate", "items": {"type": "integer"}, "uniqueItems": false },
+              "modifiedDate": {"type": "string", "title": "modifiedDate" },
               "status": { "type": "string", "title": "status" },
               "facility": { "type": "object", "$ref": "schemas/basicfacilityDto.json", "title": "facility" },
               "program": { "type": "object", "$ref": "schemas/basicProgramDto.json", "title": "program" },
@@ -79,7 +79,8 @@ schemas:
               "pricePerPack": {"type": "number", "required": false, "title": "pricePerPack" },
               "totalCost": {"type": "number", "required": false, "title": "totalCost" },
               "skipped": {"type": "boolean", "required": false, "title": "skipped" }
-          }
+          },
+          "required": ["id", "approvedQuantity", "orderable"]
       }
 
   - approveRequisitionDtoArray: |

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -49,6 +49,74 @@ schemas:
 
   - requisitionLineItemDto: !include schemas/requisitionLineItemDto.json
 
+  - approveRequisitionDto: |
+      {   "type": "object",
+          "$schema": "http://json-schema.org/draft-04/schema",
+          "title": "ApproveRequisitionDto",
+          "description": "A single requisitionDto for batch approval",
+          "properties": {
+              "id": { "type": "string", "title": "id" },
+              "modifiedDate": {"type": "array", "title": "modifiedDate", "items": {"type": "integer"}, "uniqueItems": false },
+              "status": { "type": "string", "title": "status" },
+              "facility": { "type": "object", "$ref": "schemas/basicfacilityDto.json", "title": "facility" },
+              "program": { "type": "object", "$ref": "schemas/basicProgramDto.json", "title": "program" },
+              "processingPeriod": { "type": "object", "$ref": "schemas/basicProcessingPeriodDto.json", "title": "processingPeriod" },
+              "requisitionLineItems": { "type": "array", "title": "requisitionLineItems", "items": { "type": "object", "$ref":"#/schemas/approveRequisitionLineItemDto" }, "uniqueItems": false }
+          },
+          "required": ["id", "facility", "program", "processingPeriod", "status"]
+      }
+
+
+  - approveRequisitionLineItemDto: |
+      {   "type": "object",
+          "$schema": "http://json-schema.org/draft-04/schema",
+          "title": "RequisitionLineItemDto",
+          "description": "A single requisitionLineItemDto",
+          "properties": {
+              "id": { "type": "string", "required": true, "title": "id" },
+              "orderable": { "type": "object", "$ref": "#/schemas/basicOrderableDto", "required": true, "title": "orderable" },
+              "approvedQuantity": {"type": "integer", "required": true, "title": "approvedQuantity" },
+              "pricePerPack": {"type": "number", "required": false, "title": "pricePerPack" },
+              "totalCost": {"type": "number", "required": false, "title": "totalCost" },
+              "skipped": {"type": "boolean", "required": false, "title": "skipped" }
+          }
+      }
+
+  - approveRequisitionDtoArray: |
+      {
+          "type": "array",
+          "items": { "type": "object", "$ref": "#/schemas/approveRequisitionDto" }
+      }
+
+  - requisitionError: |
+      {   "type": "object",
+          "$schema": "http://json-schema.org/draft-04/schema",
+          "title": "RequisitionError",
+          "description": "A single requisition error",
+          "properties": {
+              "errorMessage": { "type": "object", "$ref": "#/schemas/localizedMessage" },
+              "fieldErrors": { "type": "object", "$ref": "#/schemas/simpleMap" },
+              "requisitionId": { "type": "string", "title": "id" }
+          }
+      }
+
+  - requisitionErrorArray: |
+      {
+          "type": "array",
+          "items": { "type": "object", "$ref": "#/schemas/requisitionError" }
+      }
+
+  - requisitionsProcessingStatus: |
+      {   "type": "object",
+          "$schema": "http://json-schema.org/draft-04/schema",
+          "title": "RequisitionsProcessingStatus",
+          "description": "An array of all requsitions that have been processed successfully and an array of errors.",
+          "properties": {
+              "requisitions": { "type": "object", "$ref": "#/schemas/approveRequisitionDtoArray" },
+              "errors": { "type": "object", "$ref": "#/schemas/requisitionErrorArray" }
+          }
+      }
+
   - requisitionTemplate: !include schemas/requisitionTemplate.json
 
   - requisitionTemplateArray: |
@@ -63,6 +131,15 @@ schemas:
           "items": [
               { "type": "object", "$ref": "/schemas/requisitionDto.json" },
               { "type": "array", "items": { "type": "object", "$ref": "#/schemas/facility" } }
+          ]
+      }
+
+  - simpleMap: |
+      {
+          "type": "array",
+          "items": [
+              { "type": "string", "title": "key", "required": true },
+              { "type": "string", "title": "value" }
           ]
       }
 
@@ -177,6 +254,74 @@ resourceTypes:
 
 /api:
   /requisitions:
+      put:
+          is: [ secured ]
+          description: When saveAll param is present, it will save all requisitions from the request body
+          queryParameters:
+              saveAll:
+                  displayName: saveAll
+                  type: string
+                  required: false
+                  repeat: false
+          body:
+              application/json:
+                  schema: approveRequisitionDtoArray
+          responses:
+              "200":
+                  body:
+                    application/json:
+                        schema: requisitionsProcessingStatus
+              "400":
+                  body:
+                    application/json:
+                        schema: requisitionsProcessingStatus
+      post:
+          is: [ secured ]
+          description: when approveAll param is present, it will approve requisitions with passed ids
+          queryParameters:
+              approveAll:
+                  displayName: approveAll
+                  type: string
+                  required: false
+                  repeat: false
+              id:
+                  displayName: id
+                  type: string
+                  required: false
+                  repeat: true
+          responses:
+              "200":
+                  body:
+                    application/json:
+                        schema: requisitionsProcessingStatus
+              "400":
+                  body:
+                    application/json:
+                        schema: requisitionsProcessingStatus
+      get:
+          is: [ secured ]
+          description: when retrieveAll param is present, it will retrieve requisitions with passed ids
+          queryParameters:
+              retrieveAll:
+                  displayName: retrieveAll
+                  type: string
+                  required: false
+                  repeat: false
+              id:
+                  displayName: id
+                  type: string
+                  required: false
+                  repeat: true
+          responses:
+              "200":
+                  body:
+                    application/json:
+                        schema: requisitionsProcessingStatus
+              "400":
+                  body:
+                    application/json:
+                        schema: requisitionsProcessingStatus
+
       displayName: Requisition
       /initiate:
           post:

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -73,12 +73,12 @@ schemas:
           "title": "RequisitionLineItemDto",
           "description": "A single requisitionLineItemDto",
           "properties": {
-              "id": { "type": "string", "required": true, "title": "id" },
-              "orderable": { "type": "object", "$ref": "#/schemas/basicOrderableDto", "required": true, "title": "orderable" },
-              "approvedQuantity": {"type": "integer", "required": true, "title": "approvedQuantity" },
-              "pricePerPack": {"type": "number", "required": false, "title": "pricePerPack" },
-              "totalCost": {"type": "number", "required": false, "title": "totalCost" },
-              "skipped": {"type": "boolean", "required": false, "title": "skipped" }
+              "id": { "type": "string", "title": "id" },
+              "orderable": { "type": "object", "$ref": "#/schemas/basicOrderableDto", "title": "orderable" },
+              "approvedQuantity": {"type": "integer", "title": "approvedQuantity" },
+              "pricePerPack": {"type": "number", "title": "pricePerPack" },
+              "totalCost": {"type": "number", "title": "totalCost" },
+              "skipped": {"type": "boolean", "title": "skipped" }
           },
           "required": ["id", "approvedQuantity", "orderable"]
       }

--- a/src/main/resources/schemas/requisitionDto.json
+++ b/src/main/resources/schemas/requisitionDto.json
@@ -5,7 +5,7 @@
   "description": "A single requisitionDto",
   "properties": {
     "id": { "type": "string", "title": "id" },
-    "createdDate": {"type": "array", "title": "createdDate", "items": {"type": "integer" }, "uniqueItems": false },
+    "createdDate": {"type": "string", "title": "createdDate" },
     "facility": { "type": "object", "$ref": "schemas/facilityDto.json", "title": "facility" },
     "program": { "type": "object", "$ref": "schemas/programDto.json", "title": "program" },
     "supplyingFacility" : {"type": ["string", "null"], "title": "supplyingFacility"},

--- a/src/test/java/org/openlmis/requisition/dto/RequisitionsProcessingStatusDtoTest.java
+++ b/src/test/java/org/openlmis/requisition/dto/RequisitionsProcessingStatusDtoTest.java
@@ -1,0 +1,104 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.requisition.dto;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+import java.util.UUID;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequisitionsProcessingStatusDtoTest {
+  private OrderableDto orderable1;
+  private OrderableDto orderable2;
+  private OrderableDto orderable3;
+
+  private ApproveRequisitionDto requisition1;
+  private ApproveRequisitionDto requisition2;
+  private ApproveRequisitionDto requisition3;
+
+  RequisitionsProcessingStatusDto processingStatus;
+
+  @Before
+  public void setUp() throws Exception {
+    orderable1 = new OrderableDto();
+    orderable1.setId(UUID.randomUUID());
+
+    orderable2 = new OrderableDto();
+    orderable2.setId(UUID.randomUUID());
+
+    orderable3 = new OrderableDto();
+    orderable3.setId(UUID.randomUUID());
+
+    requisition1 = create(UUID.randomUUID(), orderable1, false, orderable2, true, orderable3);
+    requisition2 = create(UUID.randomUUID(), orderable1, true, orderable2, false, orderable3);
+    requisition3 = create(UUID.randomUUID(), orderable1, false, orderable2, false, orderable3);
+
+    processingStatus = new RequisitionsProcessingStatusDto();
+    processingStatus.addProcessedRequisition(requisition1);
+    processingStatus.addProcessedRequisition(requisition2);
+    processingStatus.addProcessedRequisition(requisition3);
+  }
+
+  @Test
+  public void shouldRemoveLineItemsIfProductIsSkippedInAllRequisitions() {
+    processingStatus.removeSkippedProducts();
+
+    List<ApproveRequisitionDto> requisitions = processingStatus.getRequisitionDtos();
+
+    assertFalse(requisitions.isEmpty());
+    assertEquals(requisitions.size(), 3);
+
+    for (ApproveRequisitionDto requisition : requisitions) {
+      List<ApproveRequisitionLineItemDto> lineItems = requisition.getRequisitionLineItems();
+
+      assertEquals(lineItems.size(), 2);
+      assertEquals(lineItems.get(0).getOrderable().getId(), orderable1.getId());
+      assertEquals(lineItems.get(1).getOrderable().getId(), orderable2.getId());
+    }
+  }
+
+  private ApproveRequisitionDto create(UUID key, OrderableDto orderable1, boolean skipped1,
+                                OrderableDto orderable2, boolean skipped2,
+                                OrderableDto orderable3) {
+    ApproveRequisitionDto dto = new ApproveRequisitionDto();
+    dto.setId(key);
+
+    ApproveRequisitionLineItemDto line1 = new ApproveRequisitionLineItemDto();
+    line1.setOrderable(orderable1);
+    line1.setSkipped(skipped1);
+
+    ApproveRequisitionLineItemDto line2 = new ApproveRequisitionLineItemDto();
+    line2.setOrderable(orderable2);
+    line2.setSkipped(skipped2);
+
+    ApproveRequisitionLineItemDto line3 = new ApproveRequisitionLineItemDto();
+    line3.setOrderable(orderable3);
+    line3.setSkipped(true);
+
+    dto.setRequisitionLineItems(Lists.newArrayList(line1, line2, line3));
+
+    return dto;
+  }
+
+}

--- a/src/test/java/org/openlmis/requisition/service/RequisitionSecurityServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionSecurityServiceTest.java
@@ -29,6 +29,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.openlmis.requisition.domain.Requisition;
+import org.openlmis.requisition.errorhandling.ValidationResult;
 
 import java.util.List;
 import java.util.UUID;
@@ -52,6 +53,9 @@ public class RequisitionSecurityServiceTest {
     final UUID program = UUID.randomUUID();
     final Requisition requisition = mockRequisition(facility, program);
 
+    when(permissionService.canViewRequisition(any(Requisition.class)))
+        .thenReturn(ValidationResult.success());
+
     List<Requisition> allRequisitions = Lists.newArrayList(requisition, requisition, requisition);
 
     requisitionSecurityService.filterInaccessibleRequisitions(allRequisitions);
@@ -69,6 +73,9 @@ public class RequisitionSecurityServiceTest {
 
     List<Requisition> allRequisitions = Lists.newArrayList(requisition, requisition2, requisition3);
 
+    when(permissionService.canViewRequisition(any(Requisition.class)))
+        .thenReturn(ValidationResult.success());
+
     requisitionSecurityService.filterInaccessibleRequisitions(allRequisitions);
 
     // The permission service should be called one time for each requisition (no cache hits)
@@ -83,7 +90,10 @@ public class RequisitionSecurityServiceTest {
     final Requisition requisition4 = mockRequisition(UUID.randomUUID(), UUID.randomUUID());
 
     when(permissionService.canViewRequisition(any(Requisition.class)))
-        .thenReturn(true, false, false, true);
+        .thenReturn(ValidationResult.success(),
+            ValidationResult.noPermission("accessDenied"),
+            ValidationResult.noPermission("accessDenied"),
+            ValidationResult.success());
 
     List<Requisition> allRequisitions = Lists.newArrayList(requisition, requisition2,
         requisition3, requisition4);

--- a/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
@@ -688,23 +688,10 @@ public class RequisitionServiceTest {
     when(permissionService.canUpdateRequisition(requisitionDto.getId()))
         .thenReturn(ValidationResult.noPermission("no.permission"));
 
-    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto,
-        requisitionDto.getId());
+    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto.getId());
 
     assertTrue(result.hasErrors());
     assertEquals(FailureType.NO_PERMISSION, result.getError().getType());
-  }
-
-  @Test
-  public void shouldFailValidationIfIdsDoNotMatch() {
-    when(permissionService.canUpdateRequisition(any(UUID.class)))
-        .thenReturn(ValidationResult.success());
-
-    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto,
-        UUID.randomUUID());
-
-    assertTrue(result.hasErrors());
-    assertEquals(FailureType.VALIDATION, result.getError().getType());
   }
 
   @Test
@@ -713,8 +700,7 @@ public class RequisitionServiceTest {
         .thenReturn(ValidationResult.success());
     when(requisitionRepository.findOne(requisitionDto.getId())).thenReturn(null);
 
-    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto,
-        requisitionDto.getId());
+    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto.getId());
 
     assertTrue(result.hasErrors());
     assertEquals(FailureType.NOT_FOUND, result.getError().getType());
@@ -727,8 +713,7 @@ public class RequisitionServiceTest {
     when(requisitionRepository.findOne(requisitionDto.getId())).thenReturn(requisition);
     requisition.setStatus(RELEASED);
 
-    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto,
-        requisitionDto.getId());
+    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto.getId());
 
     assertTrue(result.hasErrors());
     assertEquals(FailureType.VALIDATION, result.getError().getType());
@@ -741,8 +726,7 @@ public class RequisitionServiceTest {
     when(requisitionRepository.findOne(requisitionDto.getId())).thenReturn(requisition);
     requisition.setStatus(SUBMITTED);
 
-    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto,
-        requisitionDto.getId());
+    ValidationResult result = requisitionService.validateCanSaveRequisition(requisitionDto.getId());
 
     assertTrue(result.isSuccess());
   }

--- a/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
@@ -258,7 +258,7 @@ public class RequisitionControllerTest {
     when(initiatedRequsition.getTemplate()).thenReturn(template);
     when(requisitionRepository.findOne(uuid2)).thenReturn(initiatedRequsition);
 
-    when(requisitionService.validateCanSaveRequisition(any(RequisitionDto.class), any(UUID.class)))
+    when(requisitionService.validateCanSaveRequisition(any(UUID.class)))
         .thenReturn(ValidationResult.failedValidation("IdsMismatch"));
     when(requisitionVersionValidator.validateRequisitionTimestamps(
         any(Requisition.class), any(Requisition.class)))
@@ -281,7 +281,7 @@ public class RequisitionControllerTest {
     when(initiatedRequsition.getSupervisoryNodeId()).thenReturn(null);
     when(initiatedRequsition.getId()).thenReturn(uuid1);
 
-    when(requisitionService.validateCanSaveRequisition(requisitionDto, uuid1))
+    when(requisitionService.validateCanSaveRequisition(uuid1))
         .thenReturn(ValidationResult.success());
     when(requisitionVersionValidator.validateRequisitionTimestamps(
         any(Requisition.class), any(Requisition.class))).thenReturn(ValidationResult.success());
@@ -305,7 +305,7 @@ public class RequisitionControllerTest {
     when(requisitionDto.getFacility()).thenReturn(mock(FacilityDto.class));
     when(requisitionDto.getProgram()).thenReturn(mock(ProgramDto.class));
     when(requisitionDto.getProcessingPeriod()).thenReturn(mock(ProcessingPeriodDto.class));
-    when(requisitionService.validateCanSaveRequisition(any(RequisitionDto.class), any(UUID.class)))
+    when(requisitionService.validateCanSaveRequisition(any(UUID.class)))
         .thenReturn(ValidationResult.success());
     when(requisitionVersionValidator.validateRequisitionTimestamps(
         any(Requisition.class), any(Requisition.class))).thenReturn(ValidationResult.success());
@@ -320,8 +320,7 @@ public class RequisitionControllerTest {
     assertThatThrownBy(() -> requisitionController.updateRequisition(requisitionDto, uuid1))
         .isInstanceOf(BindingResultException.class);
 
-    verify(requisitionService).validateCanSaveRequisition(
-        any(RequisitionDto.class), any(UUID.class));
+    verify(requisitionService).validateCanSaveRequisition(any(UUID.class));
     verifyNoSubmitOrUpdate(initiatedRequsition);
   }
 

--- a/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
@@ -251,18 +251,6 @@ public class RequisitionControllerTest {
   public void shouldReturnBadRequestWhenRequisitionIdDiffersFromTheOneInUrl() throws Exception {
     RequisitionDto requisitionDto = mock(RequisitionDto.class);
     when(requisitionDto.getId()).thenReturn(uuid1);
-    when(requisitionDto.getTemplate()).thenReturn(null);
-    when(requisitionDto.getFacility()).thenReturn(mock(FacilityDto.class));
-    when(requisitionDto.getProgram()).thenReturn(mock(ProgramDto.class));
-    when(requisitionDto.getProcessingPeriod()).thenReturn(mock(ProcessingPeriodDto.class));
-    when(initiatedRequsition.getTemplate()).thenReturn(template);
-    when(requisitionRepository.findOne(uuid2)).thenReturn(initiatedRequsition);
-
-    when(requisitionService.validateCanSaveRequisition(any(UUID.class)))
-        .thenReturn(ValidationResult.failedValidation("IdsMismatch"));
-    when(requisitionVersionValidator.validateRequisitionTimestamps(
-        any(Requisition.class), any(Requisition.class)))
-        .thenReturn(ValidationResult.success());
 
     requisitionController.updateRequisition(requisitionDto, uuid2);
   }


### PR DESCRIPTION
The new batch endpoints are capable of retrieving, saving and
approving several requisitions at once. Those endpoints will
always attempt to process all the requisitions and the result
will contain information about all the requisitions that have
been successfully processed and anything that have resulted in
an error. The error messages returned are the exact same ones
as a regular endpoint would return, although they are bundled
and linked with requisition UUID. The new endpoints use a
simplified requisition and line items representation, containg
only fields that the requisition needs during approval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/43)
<!-- Reviewable:end -->
