### PR TITLE
OLMIS-6619: Performance issue on approve screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Improvements:
 * [OLMIS-6374](https://openlmis.atlassian.net/browse/OLMIS-6374): Add new profile for audit logging.
 * [OLMIS-6408](https://openlmis.atlassian.net/browse/OLMIS-6408): Added pageable validator.
 * [OLMIS-6402](https://openlmis.atlassian.net/browse/OLMIS-6402): Renamed versionId field to versionNumber.
+* [OLMIS-6619](https://openlmis.atlassian.net/browse/OLMIS-6619): Improved the `GET /api/requisitionsForApproval` endpoint performance 
 
 Bug fixes:
 * [OLMIS-6230](https://openlmis.atlassian.net/browse/OLMIS-6230): Fixed bug with null value of average consumption when column is not selected in template.

--- a/src/integration-test/java/org/openlmis/requisition/repository/BaseRequisitionRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/BaseRequisitionRepositoryIntegrationTest.java
@@ -16,22 +16,14 @@
 package org.openlmis.requisition.repository;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.openlmis.requisition.domain.requisition.RequisitionStatus.APPROVED;
-import static org.openlmis.requisition.domain.requisition.RequisitionStatus.AUTHORIZED;
 import static org.openlmis.requisition.domain.requisition.RequisitionStatus.INITIATED;
-import static org.openlmis.requisition.domain.requisition.RequisitionStatus.IN_APPROVAL;
-import static org.openlmis.requisition.domain.requisition.RequisitionStatus.REJECTED;
-import static org.openlmis.requisition.domain.requisition.RequisitionStatus.SKIPPED;
-import static org.openlmis.requisition.domain.requisition.RequisitionStatus.SUBMITTED;
 
-import com.google.common.collect.Lists;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import javax.persistence.EntityManager;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -39,7 +31,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.openlmis.requisition.domain.RequisitionTemplate;
 import org.openlmis.requisition.domain.requisition.Requisition;
 import org.openlmis.requisition.domain.requisition.RequisitionDataBuilder;
-import org.openlmis.requisition.domain.requisition.RequisitionStatus;
 import org.openlmis.requisition.domain.requisition.StatusChange;
 import org.openlmis.requisition.domain.requisition.StockAdjustmentReason;
 import org.openlmis.requisition.testutils.StatusChangeDataBuilder;
@@ -95,7 +86,12 @@ public abstract class BaseRequisitionRepositoryIntegrationTest extends
           .withDraftStatusMessage("draft status message " + nextInstanceNumber)
           .buildAsNew();
 
-    addStatusChanges(requisition, 0);
+    StatusChange statusChange = new StatusChangeDataBuilder()
+        .withRequisition(requisition)
+        .withStatus(INITIATED)
+        .buildAsNew();
+
+    requisition.getStatusChanges().add(statusChange);
 
     StockAdjustmentReason reason = generateStockAdjustmentReason();
     requisition.setStockAdjustmentReasons(newArrayList(reason));
@@ -105,109 +101,11 @@ public abstract class BaseRequisitionRepositoryIntegrationTest extends
     return requisition;
   }
 
-  protected StockAdjustmentReason generateStockAdjustmentReason() {
-    StockAdjustmentReason reason = new StockAdjustmentReasonDataBuilder()
+  private StockAdjustmentReason generateStockAdjustmentReason() {
+    return new StockAdjustmentReasonDataBuilder()
         .withIsFreeTextAllowed(false)
         .withName(RandomStringUtils.random(5))
         .build();
-    return reason;
   }
 
-  /**
-   * Adds status changes for the given requisition.
-   *
-   * @param requisition the given requisition
-   * @param rejectedCount define how many times the given requisition should be rejected. Zero means
-   *                      that the given requisition will not have rejected status change.
-   */
-  void addStatusChanges(Requisition requisition, int rejectedCount) {
-    requisition.setStatusChanges(Lists.newArrayList());
-
-    if (requisition.getStatus() == RequisitionStatus.INITIATED) {
-      addStatusChangesForInitiatedRequisition(requisition);
-    } else if (requisition.getStatus() == RequisitionStatus.SKIPPED) {
-      addStatusChangesForSkippedRequisition(requisition, rejectedCount);
-    } else if (requisition.getStatus() == RequisitionStatus.REJECTED) {
-      addStatusChangesForRejectedRequisition(requisition, rejectedCount);
-    } else if (requisition.getStatus() == RequisitionStatus.SUBMITTED) {
-      addStatusChangesForSubmittedRequisition(requisition, rejectedCount);
-    } else if (requisition.getStatus() == RequisitionStatus.AUTHORIZED) {
-      addStatusChangesForAuthorizedRequisition(requisition, rejectedCount);
-    } else if (requisition.getStatus() == RequisitionStatus.IN_APPROVAL) {
-      addStatusChangesForInApprovalRequisition(requisition, rejectedCount);
-    } else if (requisition.getStatus() == RequisitionStatus.APPROVED) {
-      addStatusChangesForApprovedRequisition(requisition, rejectedCount);
-    } else if (requisition.getStatus() == RequisitionStatus.RELEASED
-        || requisition.getStatus() == RequisitionStatus.RELEASED_WITHOUT_ORDER) {
-      addStatusChangesForReleasedRequisition(requisition, rejectedCount);
-    }
-  }
-
-  private void addStatusChangesForInitiatedRequisition(Requisition requisition) {
-    addStatusChange(requisition, INITIATED);
-  }
-
-  private void addStatusChangesForRejectedRequisition(Requisition requisition,
-      int rejectedCount) {
-    addStatusChangesForInitiatedRequisition(requisition);
-
-    for (int i = 0; i < rejectedCount; ++i) {
-      addStatusChange(requisition, SUBMITTED);
-      addStatusChange(requisition, AUTHORIZED);
-      addStatusChange(requisition, IN_APPROVAL);
-      addStatusChange(requisition, REJECTED);
-    }
-  }
-
-  private void addStatusChangesForSkippedRequisition(Requisition requisition,
-      int rejectedCount) {
-    addStatusChangesForRejectedRequisition(requisition, rejectedCount);
-    addStatusChange(requisition, SKIPPED);
-  }
-
-  private void addStatusChangesForSubmittedRequisition(Requisition requisition,
-      int rejectedCount) {
-    addStatusChangesForRejectedRequisition(requisition, rejectedCount);
-    addStatusChange(requisition, SUBMITTED);
-  }
-
-  private void addStatusChangesForAuthorizedRequisition(Requisition requisition,
-      int rejectedCount) {
-    addStatusChangesForSubmittedRequisition(requisition, rejectedCount);
-    addStatusChange(requisition, AUTHORIZED);
-  }
-
-  private void addStatusChangesForInApprovalRequisition(Requisition requisition,
-      int rejectedCount) {
-    addStatusChangesForAuthorizedRequisition(requisition, rejectedCount);
-    addStatusChange(requisition, IN_APPROVAL);
-  }
-
-  private void addStatusChangesForApprovedRequisition(Requisition requisition, int rejectedCount) {
-    addStatusChangesForInApprovalRequisition(requisition, rejectedCount);
-    addStatusChange(requisition, APPROVED);
-  }
-
-  private void addStatusChangesForReleasedRequisition(Requisition requisition, int rejectedCount) {
-    addStatusChangesForApprovedRequisition(requisition, rejectedCount);
-    addStatusChange(requisition, requisition.getStatus());
-  }
-
-  private void addStatusChange(Requisition requisition, RequisitionStatus status) {
-    StatusChange statusChange = new StatusChangeDataBuilder()
-        .withRequisition(requisition)
-        .withStatus(status)
-        .buildAsNew();
-
-    requisition.getStatusChanges().add(statusChange);
-
-    try {
-      // we use createdDate which is set automatically before saving into the database
-      // because of that we wait some time between statuses.
-      TimeUnit.MILLISECONDS.sleep(10);
-    } catch (InterruptedException exp) {
-      Thread.currentThread().interrupt();
-      throw new IllegalStateException(exp);
-    }
-  }
 }

--- a/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
@@ -89,7 +89,7 @@ public class RequisitionRepositoryIntegrationTest
     extends BaseRequisitionRepositoryIntegrationTest {
 
   private List<Requisition> requisitions;
-  
+
   private Pageable pageRequest = new PageRequest(
       Pagination.DEFAULT_PAGE_NUMBER, Pagination.NO_PAGINATION);
 
@@ -506,7 +506,7 @@ public class RequisitionRepositoryIntegrationTest
     UUID programId = UUID.randomUUID();
     UUID periodId = UUID.randomUUID();
 
-    Requisition requisition1 =  generateInstance(facilityId, programId, periodId);
+    Requisition requisition1 = generateInstance(facilityId, programId, periodId);
     requisition1.setSupervisoryNodeId(supervisoryNodeId);
 
     Requisition requisition2 = generateInstance(facilityId, programId, periodId);
@@ -526,7 +526,7 @@ public class RequisitionRepositoryIntegrationTest
     UUID programId = UUID.randomUUID();
     UUID periodId = UUID.randomUUID();
 
-    Requisition regularRequisition =  generateInstance(facilityId, programId, periodId);
+    Requisition regularRequisition = generateInstance(facilityId, programId, periodId);
     Requisition emergencyRequisition1 = generateInstance(facilityId, programId, periodId);
     Requisition emergencyRequisition2 = generateInstance(facilityId, programId, periodId);
 
@@ -538,7 +538,7 @@ public class RequisitionRepositoryIntegrationTest
 
     entityManager.flush();
   }
-  
+
   @Test
   public void searchByProgramSupervisoryNodePairsShouldFindIfIdsAndStatusMatch() {
     // given
@@ -549,14 +549,63 @@ public class RequisitionRepositoryIntegrationTest
     matchingRequisition1.setProgramId(programId);
     matchingRequisition1.setSupervisoryNodeId(supervisoryNodeId);
     matchingRequisition1.setStatus(RequisitionStatus.AUTHORIZED);
-    addStatusChanges(matchingRequisition1, 4);
-    repository.save(matchingRequisition1);
+
+    // simulation that the requisition has been rejected 4 times
+    matchingRequisition1
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition1)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition1);
+
+    matchingRequisition1
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition1)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition1);
+
+    matchingRequisition1
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition1)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition1);
+
+    matchingRequisition1
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition1)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition1);
 
     Requisition matchingRequisition2 = requisitions.get(1);
     matchingRequisition2.setProgramId(programId);
     matchingRequisition2.setSupervisoryNodeId(supervisoryNodeId);
     matchingRequisition2.setStatus(RequisitionStatus.IN_APPROVAL);
-    addStatusChanges(matchingRequisition2, 3);
+
+    // simulation that the requisition has been rejected 3 times
+    matchingRequisition2
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition2)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition2);
+
+    matchingRequisition2
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition2)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition2);
+
+    matchingRequisition2
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition2)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition2);
+
     repository.save(matchingRequisition2);
 
     Set<Pair<UUID, UUID>> programNodePairs =
@@ -565,7 +614,7 @@ public class RequisitionRepositoryIntegrationTest
     // when
     Page<Requisition> results = repository
         .searchApprovableRequisitionsByProgramSupervisoryNodePairs(programNodePairs, pageRequest);
-    
+
     // then
     assertEquals(2, results.getTotalElements());
   }
@@ -581,16 +630,37 @@ public class RequisitionRepositoryIntegrationTest
     matchingRequisition1.setSupervisoryNodeId(supervisoryNodeId);
     matchingRequisition1.setStatus(RequisitionStatus.AUTHORIZED);
     matchingRequisition1.setEmergency(false);
-    addStatusChanges(matchingRequisition1, 2);
-    repository.save(matchingRequisition1);
+    matchingRequisition1.getStatusChanges().clear();
+
+    // simulation that the requisition has been rejected 2 times
+    matchingRequisition1
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition1)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition1);
+
+    matchingRequisition1
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition1)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition1);
 
     Requisition matchingRequisition2 = requisitions.get(1);
     matchingRequisition2.setProgramId(programId);
     matchingRequisition2.setSupervisoryNodeId(supervisoryNodeId);
     matchingRequisition2.setStatus(RequisitionStatus.IN_APPROVAL);
     matchingRequisition2.setEmergency(true);
-    addStatusChanges(matchingRequisition2, 0);
-    repository.save(matchingRequisition2);
+    matchingRequisition2.getStatusChanges().clear();
+
+    // simulation that the requisition has not been rejected
+    matchingRequisition2
+        .getStatusChanges()
+        .add(new StatusChangeDataBuilder()
+            .forAuthorizedRequisition(matchingRequisition2)
+            .buildAsNew());
+    saveAndFlushWithDelay(matchingRequisition2);
 
     Set<Pair<UUID, UUID>> programNodePairs =
         singleton(new ImmutablePair<>(programId, supervisoryNodeId));
@@ -752,15 +822,15 @@ public class RequisitionRepositoryIntegrationTest
 
     Set<Pair<UUID, UUID>> programNodePairs =
         singleton(new ImmutablePair<>(programId, supervisoryNodeId));
-    
+
     // when
     Page<Requisition> results = repository
         .searchApprovableRequisitionsByProgramSupervisoryNodePairs(programNodePairs, pageRequest);
-    
+
     // then
     assertEquals(0, results.getTotalElements());
   }
-  
+
   @Test
   public void searchByProgramSupervisoryNodePairsShouldNotFindIfStatusDoesNotMatch() {
     // given

--- a/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
@@ -550,7 +550,7 @@ public class RequisitionRepositoryIntegrationTest
     matchingRequisition1.setSupervisoryNodeId(supervisoryNodeId);
     matchingRequisition1.setStatus(RequisitionStatus.AUTHORIZED);
 
-    // simulation that the requisition has been rejected 4 times
+    // simulation that the requisition has been rejected 3 times
     matchingRequisition1
         .getStatusChanges()
         .add(new StatusChangeDataBuilder()
@@ -584,7 +584,7 @@ public class RequisitionRepositoryIntegrationTest
     matchingRequisition2.setSupervisoryNodeId(supervisoryNodeId);
     matchingRequisition2.setStatus(RequisitionStatus.IN_APPROVAL);
 
-    // simulation that the requisition has been rejected 3 times
+    // simulation that the requisition has been rejected 2 times
     matchingRequisition2
         .getStatusChanges()
         .add(new StatusChangeDataBuilder()
@@ -632,7 +632,7 @@ public class RequisitionRepositoryIntegrationTest
     matchingRequisition1.setEmergency(false);
     matchingRequisition1.getStatusChanges().clear();
 
-    // simulation that the requisition has been rejected 2 times
+    // simulation that the requisition has been rejected 1 times
     matchingRequisition1
         .getStatusChanges()
         .add(new StatusChangeDataBuilder()


### PR DESCRIPTION
Because of the load graph query hint, the pagination has been done in memory instead of in the database. Also, status changes have been loaded for all requisitions even if we wanted only 10 requisitions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/50)
<!-- Reviewable:end -->
