### PR TITLE
OLMIS-6620: Set lazy flag for available_products

### DIFF
--- a/src/main/java/org/openlmis/requisition/domain/requisition/Requisition.java
+++ b/src/main/java/org/openlmis/requisition/domain/requisition/Requisition.java
@@ -133,6 +133,7 @@ public class Requisition extends BaseTimestampedEntity {
   static final String EXTRA_DATA_ORIGINAL_REQUISITION_ID = "originalRequisition";
 
   private static final int LINE_ITEMS_BATCH_SIZE = 100;
+  private static final int AVAILABLE_PRODUCTS_BATCH_SIZE = 1000;
 
   @OneToMany(
       mappedBy = "requisition",
@@ -226,7 +227,8 @@ public class Requisition extends BaseTimestampedEntity {
   @Setter
   private List<Requisition> previousRequisitions;
 
-  @ElementCollection(fetch = FetchType.EAGER)
+  @ElementCollection(fetch = FetchType.LAZY)
+  @BatchSize(size = AVAILABLE_PRODUCTS_BATCH_SIZE)
   @CollectionTable(name = "available_products", joinColumns = @JoinColumn(name = "requisitionId"))
   @Getter
   @Setter


### PR DESCRIPTION
The `availableProducts` field in the `Requisition` class had set the `fetch` flag to `EAGER`. Because of that each time when we retrieve requisitions from the database, the data related to that field are also retrieved even if we don't require those data for instance when we call the search endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openlmis/openlmis-requisition/51)
<!-- Reviewable:end -->
