### PR TITLE
TZUP-428 Disable some columns validation if patients tab is enabled f…

### DIFF
--- a/src/main/java/org/openlmis/requisition/dto/RequisitionTemplateDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/RequisitionTemplateDto.java
@@ -76,6 +76,10 @@ public final class RequisitionTemplateDto extends BaseRequisitionTemplateDto
   @Setter
   private Boolean requisitionReportOnly;
 
+  @Getter
+  @Setter
+  private Boolean patientsTabEnabled;
+
   @Override
   @JsonIgnore
   public UUID getProgramId() {

--- a/src/main/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidator.java
+++ b/src/main/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidator.java
@@ -105,12 +105,14 @@ public class RequisitionTemplateDtoValidator extends BaseValidator {
     this.errors = errors;
 
     RequisitionTemplateDto template = (RequisitionTemplateDto) target;
-
-    validateRequestedQuantity(template);
+    boolean patientsTabEnabled = Boolean.TRUE.equals(template.getPatientsTabEnabled());
+    if (!patientsTabEnabled) {
+      validateRequestedQuantity(template);
+      validateCalculatedFields(template);
+    }
     validateColumns(template);
-    validateCalculatedFields(template);
 
-    if (!errors.hasErrors()) {
+    if (!errors.hasErrors() && !patientsTabEnabled) {
       validateCalculatedField(template, STOCK_ON_HAND,
           ERROR_MUST_BE_DISPLAYED_WHEN_ON_HAND_IS_CALCULATED, TOTAL_CONSUMED_QUANTITY
       );

--- a/src/main/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidator.java
+++ b/src/main/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidator.java
@@ -109,8 +109,9 @@ public class RequisitionTemplateDtoValidator extends BaseValidator {
     if (!patientsTabEnabled) {
       validateRequestedQuantity(template);
       validateCalculatedFields(template);
+      validateNumberOfPeriodsToAverage(template);
     }
-    validateColumns(template);
+    validateColumns(template, patientsTabEnabled);
 
     if (!errors.hasErrors() && !patientsTabEnabled) {
       validateCalculatedField(template, STOCK_ON_HAND,
@@ -123,9 +124,7 @@ public class RequisitionTemplateDtoValidator extends BaseValidator {
       validateForAverageConsumption(template);
     }
 
-    validateNumberOfPeriodsToAverage(template);
-
-    if (template.isPopulateStockOnHandFromStockCards()) {
+    if (template.isPopulateStockOnHandFromStockCards() && !patientsTabEnabled) {
       validateStockManagementFields(template);
     }
 
@@ -193,7 +192,7 @@ public class RequisitionTemplateDtoValidator extends BaseValidator {
     }
   }
 
-  private void validateColumns(RequisitionTemplateDto template) {
+  private void validateColumns(RequisitionTemplateDto template, boolean patientsTabEnabled) {
     for (RequisitionTemplateColumnDto column : template.getColumnsMap().values()) {
       rejectIfNotUtf8(
           errors, column.getLabel(), COLUMNS_MAP,
@@ -201,7 +200,9 @@ public class RequisitionTemplateDtoValidator extends BaseValidator {
       );
 
       validateColumnDefinition(column);
-      validateChosenSources(template, column);
+      if (!patientsTabEnabled) {
+        validateChosenSources(template, column);
+      }
 
       Set<AvailableRequisitionColumnOptionDto> options = column
           .getColumnDefinition()


### PR DESCRIPTION
…or requisition template

Please, @sradziszewski take a look deeply if I excluded the correct validations or if I had missed any.

I decided to edit the `RequisitionTemplateDto` and to add the flag there, but intentionally as `Boolean` not `boolean`, so that if some existing requisition templates are edited etc, the `patientsTabEnabled` flag wouldn't be visible in the JSON (because it'd be `null`). I guess it's better than returning it every time with `patientsTabEnabled: false`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/78)
<!-- Reviewable:end -->
