### PR TITLE
TZUP-488 Fix NullPointerException when trying to unbox null value in …

### DIFF
--- a/src/main/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidator.java
+++ b/src/main/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidator.java
@@ -251,7 +251,7 @@ public class RequisitionTemplateDtoValidator extends BaseValidator {
       Set<SourceType> sources = definition.getSources();
 
       if (sources.size() > 1 && template.isColumnUserInput(definition.getName())
-          && !template.getRequisitionReportOnly()) {
+          && !Boolean.TRUE.equals(template.getRequisitionReportOnly())) {
         rejectIfNotDisplayed(
             errors, template, definition.getName(), COLUMNS_MAP,
             new Message(ERROR_MUST_BE_DISPLAYED, definition.getName())


### PR DESCRIPTION
…the validation if statement

It was throwing "cannot unbox null value" when trying to negate the `!template.getRequisitionReportOnly()`, because we can't do `!null`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/80)
<!-- Reviewable:end -->
