### PR TITLE
CQI-14: Disable demo data loading for integration tests

### DIFF
--- a/src/integration-test/java/org/openlmis/requisition/AuditLogInitializerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/AuditLogInitializerIntegrationTest.java
@@ -55,7 +55,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@ActiveProfiles({"test", "init-audit-log"})
+@ActiveProfiles({"test", "init-audit-log", "test-run"})
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class AuditLogInitializerIntegrationTest {

--- a/src/integration-test/java/org/openlmis/requisition/ExposedMessageSourceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/ExposedMessageSourceIntegrationTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 public class ExposedMessageSourceIntegrationTest {
 
   @Autowired

--- a/src/integration-test/java/org/openlmis/requisition/JaVersIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/JaVersIntegrationTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class JaVersIntegrationTest {
 

--- a/src/integration-test/java/org/openlmis/requisition/repository/BaseCrudRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/BaseCrudRepositoryIntegrationTest.java
@@ -31,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @Transactional
 public abstract class BaseCrudRepositoryIntegrationTest<T extends BaseEntity> {
 

--- a/src/integration-test/java/org/openlmis/requisition/service/RequisitionServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/service/RequisitionServiceIntegrationTest.java
@@ -99,7 +99,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @DirtiesContext()
 @SuppressWarnings("PMD.TooManyMethods")
 public class RequisitionServiceIntegrationTest {

--- a/src/integration-test/java/org/openlmis/requisition/web/BaseWebIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/BaseWebIntegrationTest.java
@@ -122,7 +122,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles({"test", "test-run"})
 @DirtiesContext
 @SuppressWarnings("PMD.TooManyMethods")
 public abstract class BaseWebIntegrationTest {

--- a/src/main/java/org/openlmis/requisition/TestDataInitializer.java
+++ b/src/main/java/org/openlmis/requisition/TestDataInitializer.java
@@ -29,7 +29,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile("demo-data")
+@Profile("demo-data & !test-run")
 @Order(5)
 public class TestDataInitializer implements CommandLineRunner {
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(TestDataInitializer.class);


### PR DESCRIPTION
Demo data was previously being loaded before the tests were run, so they were affected by records fetched from a csv.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/90)
<!-- Reviewable:end -->
