### PR TITLE
Panel 'Number of Requisitions to be created this month' on home page should not count emergency requisitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Improvements:
 * Stabilized consul registration and health checks
 * [ODRC-67](https://openlmis.atlassian.net/browse/ODRC-67): Added a locale cookie to communication between services
 to ensure notifications are returned in the correct language.
+* [ODRC-101](https://openlmis.atlassian.net/browse/ODRC-101): Panel 'Number of Requisitions to be 
+  created this month' on home page should not count emergency requisitions
 
 8.5.0 / 2025-11-27
 ==================

--- a/src/main/java/org/openlmis/requisition/service/RequisitionService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionService.java
@@ -860,9 +860,9 @@ public class RequisitionService {
     if (maxRequisitionForFacility == 0) {
       requisitionStatsData.setRequisitionsToBeCreated(0L);
     } else {
-      Long createdRequisitions = calculateCurrentlyCreatedRequisitions(activelySupportedPrograms,
-          currentFacilityPeriods, facilityId, postSubmittedStatuses);
-      long requisitionsToBeCreated = maxRequisitionForFacility - createdRequisitions;
+      Long createdRegularRequisitions = calculateCurrentlyCreatedRegularRequisitions(
+          activelySupportedPrograms, currentFacilityPeriods, facilityId, postSubmittedStatuses);
+      long requisitionsToBeCreated = maxRequisitionForFacility - createdRegularRequisitions;
       requisitionStatsData.setRequisitionsToBeCreated(requisitionsToBeCreated);
     }
 
@@ -1042,11 +1042,11 @@ public class RequisitionService {
     });
   }
 
-  private Long calculateCurrentlyCreatedRequisitions(
+  private Long calculateCurrentlyCreatedRegularRequisitions(
       List<SupportedProgramDto> activelySupportedPrograms,
       Set<ProcessingPeriodDto> currentFacilityPeriods, UUID facilityId,
       List<RequisitionStatus> postSubmittedStatuses) {
-    Profiler profiler = new Profiler("CALCULATE_CURRENTLY_CREATED_REQUISITIONS");
+    Profiler profiler = new Profiler("CALCULATE_CURRENTLY_CREATED_REGULAR_REQUISITIONS");
     profiler.setLogger(LOGGER);
 
     profiler.start("GET_ACTIVELY_SUPPORTED_PROGRAMS_IDS");
@@ -1060,7 +1060,7 @@ public class RequisitionService {
 
     profiler.stop().log();
     return requisitionRepository.countRequisitions(
-        currentFacilityPeriodsIds, facilityId, activelySupportedProgramsIds, null,
+        currentFacilityPeriodsIds, facilityId, activelySupportedProgramsIds, false,
         postSubmittedStatuses
     );
   }

--- a/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
@@ -1634,7 +1634,7 @@ public class RequisitionServiceTest {
         any(LocalDate.class), any(LocalDate.class)))
         .thenReturn(singletonList(DtoGenerator.of(ProcessingPeriodDto.class)));
     when(requisitionRepository.countRequisitions(any(List.class), eq(facility.getId()),
-        any(List.class), eq(null), any(List.class)))
+        any(List.class), eq(false), any(List.class)))
         .thenReturn(0L);
 
     // when


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/121)
<!-- Reviewable:end -->
