### PR TITLE
[OLMIS-8223] Fix apostrophe bug in messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to ensure notifications are returned in the correct language.
 * [ODRC-101](https://openlmis.atlassian.net/browse/ODRC-101): Panel 'Number of Requisitions to be 
   created this month' on home page should not count emergency requisitions
 
+Bug fixes:
+* [OLMIS-8223](https://openlmis.atlassian.net/browse/OLMIS-8223): Fix placeholder bug in messages
+
+
 8.5.0 / 2025-11-27
 ==================
 

--- a/src/main/java/org/openlmis/requisition/i18n/ExposedMessageSourceImpl.java
+++ b/src/main/java/org/openlmis/requisition/i18n/ExposedMessageSourceImpl.java
@@ -15,12 +15,14 @@
 
 package org.openlmis.requisition.i18n;
 
+import java.text.MessageFormat;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.lang.NonNull;
 
 public class ExposedMessageSourceImpl extends ReloadableResourceBundleMessageSource implements
     ExposedMessageSource {
@@ -29,6 +31,13 @@ public class ExposedMessageSourceImpl extends ReloadableResourceBundleMessageSou
     clearCacheIncludingAncestors();
     PropertiesHolder propertiesHolder = getMergedProperties(locale);
     return propertiesHolder.getProperties();
+  }
+
+  @Override
+  @NonNull
+  protected MessageFormat createMessageFormat(@NonNull String msg, @NonNull Locale locale) {
+    String safe = msg.replaceAll("(?<!')'(?!')", "''");
+    return super.createMessageFormat(safe, locale);
   }
 
   /**

--- a/src/test/java/org/openlmis/requisition/i18n/ExposedMessageSourceImplTest.java
+++ b/src/test/java/org/openlmis/requisition/i18n/ExposedMessageSourceImplTest.java
@@ -1,0 +1,39 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.i18n;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+import java.util.Properties;
+import org.junit.Test;
+
+public class ExposedMessageSourceImplTest {
+
+  @Test
+  public void apostropheWithPlaceholderIsRenderedCorrectly() {
+    ExposedMessageSourceImpl source = new ExposedMessageSourceImpl();
+    source.setDefaultEncoding("UTF-8");
+    Properties messages = new Properties();
+    messages.setProperty("test.apostrophe", "L'établissement {0}");
+    source.setCommonMessages(messages);
+
+    String result = source.getMessage("test.apostrophe",
+        new Object[] {"abc"}, Locale.FRENCH);
+
+    assertEquals("L'établissement abc", result);
+  }
+}


### PR DESCRIPTION
Overrode createMessageFormat in ExposedMessageSourceImpl files across 14 repos (auth, buq, cce, dhis2-integration, diagnostics, fulfillment, hapifhir, notification, referencedata, report, requisition, stockmanagement, template-service, one-network-integration-service).

When an exception with a Message invokes, @ControllerAdvice calls messageSource.getMessage(), which Spring resolves by calling createMessageFormat() — which I override.

It detects singular `'` in messages and converts them to `''`. Escaped `''` in messages remain unchanged.

To test I built requisition and referencedata, switched to :latest in ref-distro, then tested with requests:

```
GET /api/requisitions/search?requisitionStatus=BOGUS
Accept-Language: fr
Authorization: Bearer <token>
```

Response — 400 Bad Request:

```json
{
  "messageKey": "requisition.error.validation.params.requisitionStatus.notValidStatus",
  "message": "Le paramètre \"requisitionStatus\" n'est pas un Statut de Demande d'achat valide: [BOGUS]."
}
```

And:

```
POST /api/requisitions/initiate?facility=00000000-0000-0000-0000-000000000000&program=00000000-0000-0000-0000-000000000000&suggestedPeriod=00000000-0000-0000-0000-000000000000&emergency=false
Accept-Language: fr
Authorization: Bearer <token>
```

Response — 500 Internal Server Error (requisition wraps a 400 from referencedata):

```json
{
  "status": 500,
  "error": "Internal Server Error",
  "message": "400 : [{\n  \"messageKey\" : \"referenceData.error.program.notFound.with.id\",\n  \"message\" : \"Impossible de trouver le programme avec l'ID : 00000000-0000-0000-0000-000000000000\"\n}]",
  "path": "/api/requisitions/initiate"
}
```

Apostrophes are preserved, and `{0}` placeholders are replaced.

Includes unit test ExposedMessageSourceImplTest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/122)
<!-- Reviewable:end -->
