### PR TITLE
[MALAWISUP-7022] Fix placeholder limit in requisitions search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to ensure notifications are returned in the correct language.
 * [ODRC-101](https://openlmis.atlassian.net/browse/ODRC-101): Panel 'Number of Requisitions to be 
   created this month' on home page should not count emergency requisitions
 
+Bug fixes:
+* [MALAWISUP-7022](https://openlmis.atlassian.net/browse/MALAWISUP-7022): Fix /api/requisitions/search failing for users with many permissions (Postgres bind-parameter limit).
+
+
 8.5.0 / 2025-11-27
 ==================
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     compile "net.sf.jasperreports:jasperreports:6.5.1"
     compile "org.apache.poi:poi:3.15"
     compile "org.postgresql:postgresql:42.6.2"
+    compile "io.hypersistence:hypersistence-utils-hibernate-52:3.7.6"
     compile "org.projectlombok:lombok"
     compile "org.slf4j:slf4j-ext"
     compile "org.springframework.boot:spring-boot-starter-data-jpa"

--- a/src/main/java/org/openlmis/requisition/CustomHibernateContributor.java
+++ b/src/main/java/org/openlmis/requisition/CustomHibernateContributor.java
@@ -1,0 +1,36 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition;
+
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.spi.MetadataBuilderContributor;
+import org.hibernate.dialect.function.SQLFunctionTemplate;
+import org.hibernate.type.BooleanType;
+
+// Avoids the Postgres bind-parameter limit when a user has many permissions
+public class CustomHibernateContributor implements MetadataBuilderContributor {
+
+  @Override
+  public void contribute(MetadataBuilder metadataBuilder) {
+    metadataBuilder.applySqlFunction("text_any",
+        new SQLFunctionTemplate(BooleanType.INSTANCE, "?1 = ANY(?2)"));
+
+    metadataBuilder.applySqlFunction("uuid_pair_any",
+        new SQLFunctionTemplate(BooleanType.INSTANCE,
+            "EXISTS (SELECT 1 FROM unnest(?3::uuid[], ?4::uuid[]) AS t(p,s) "
+                + "WHERE t.p = ?1 AND t.s = ?2)"));
+  }
+}

--- a/src/main/java/org/openlmis/requisition/domain/requisition/Requisition.java
+++ b/src/main/java/org/openlmis/requisition/domain/requisition/Requisition.java
@@ -39,6 +39,8 @@ import static org.openlmis.requisition.i18n.MessageKeys.ERROR_SKIP_FAILED_WRONG_
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import io.hypersistence.utils.hibernate.type.array.StringArrayType;
+import io.hypersistence.utils.hibernate.type.array.UUIDArrayType;
 import java.lang.reflect.InvocationTargetException;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -82,6 +84,7 @@ import lombok.Setter;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
 import org.javers.core.metamodel.annotation.DiffIgnore;
 import org.javers.core.metamodel.annotation.TypeName;
 import org.joda.money.CurrencyUnit;
@@ -117,6 +120,12 @@ import org.springframework.util.CollectionUtils;
 @SuppressWarnings("PMD.TooManyMethods")
 @Entity
 @TypeName("Requisition")
+@TypeDef(name = "string-array",
+    typeClass = StringArrayType.class,
+    defaultForType = String[].class)
+@TypeDef(name = "uuid-array",
+    typeClass = UUIDArrayType.class,
+    defaultForType = UUID[].class)
 @Table(name = "requisitions")
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/org/openlmis/requisition/repository/custom/impl/RequisitionRepositoryImpl.java
+++ b/src/main/java/org/openlmis/requisition/repository/custom/impl/RequisitionRepositoryImpl.java
@@ -527,13 +527,18 @@ public class RequisitionRepositoryImpl
             createProgramNodePairPredicate(builder, root, programNodePairs)));
   }
 
+  // Bind permissions as one array param — keeps placeholder count constant
   private Predicate createPermissionStringsPredicate(Root<Requisition> root,
       List<String> userPermissionStrings) {
     Join<Requisition, RequisitionPermissionString> permissionStringJoin = root
         .join("permissionStrings");
     Expression<String> permissionStringExp = permissionStringJoin.get("permissionString");
 
-    return permissionStringExp.in(userPermissionStrings);
+    String[] perms = userPermissionStrings.toArray(new String[0]);
+    CriteriaBuilder builder = getCriteriaBuilder();
+    return builder.isTrue(builder.function("text_any", Boolean.class,
+        permissionStringExp,
+        builder.literal(perms)));
   }
 
   private <T> CriteriaQuery<T> prepareApprovableQuery(CriteriaBuilder builder,
@@ -584,20 +589,21 @@ public class RequisitionRepositoryImpl
     return query.where(predicate);
   }
 
+  // Bind program/node pairs as two parallel array params — keeps placeholder count constant
   private Predicate createProgramNodePairPredicate(CriteriaBuilder builder,
       Root<Requisition> root, Set<Pair<UUID, UUID>> programNodePairs) {
-    Predicate[] combinedPredicates = new Predicate[programNodePairs.size()];
+    UUID[] programIds = programNodePairs.stream()
+        .map(Pair::getLeft)
+        .toArray(UUID[]::new);
+    UUID[] nodeIds = programNodePairs.stream()
+        .map(Pair::getRight)
+        .toArray(UUID[]::new);
 
-    int index = 0;
-    for (Pair pair : programNodePairs) {
-      Predicate predicate = builder.conjunction();
-      predicate = addEqualFilter(predicate, builder, root, PROGRAM_ID, pair.getLeft());
-      predicate = addEqualFilter(predicate, builder, root, SUPERVISORY_NODE_ID, pair.getRight());
-
-      combinedPredicates[index++] = predicate;
-    }
-
-    return builder.or(combinedPredicates);
+    return builder.isTrue(builder.function("uuid_pair_any", Boolean.class,
+        root.get(PROGRAM_ID),
+        root.get(SUPERVISORY_NODE_ID),
+        builder.literal(programIds),
+        builder.literal(nodeIds)));
   }
 
   private <T> CriteriaQuery<T> addSortProperties(CriteriaBuilder builder,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,6 +22,7 @@ spring.jpa.properties.hibernate.default_schema=requisition
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.jdbc.batch_size=20
 spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.metadata_builder_contributor=org.openlmis.requisition.CustomHibernateContributor
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true


### PR DESCRIPTION
Search returned HTTP 500 for users with broad access — query exceeded Postgres parameter limit

Rewrote the two user-scoped predicates to bind arrays via Postgres instead of generating N placeholders

The limit is 32 767 on pgjdbc 42.2.6 (OpenLMIS-Malawi rel-8.4.0) and 65 535 on 42.6.2 (OpenLMIS master)
Reproducible by inserting fake right_assignments for admin (~25 000 on the older driver, ~70 000 on the newer)
GET /api/requisitions/search then returns HTTP 500 with `Could not roll back JPA transaction`
With the fix the same data returns HTTP 200

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/123)
<!-- Reviewable:end -->
