### PR TITLE
OLMIS-8231: Preserve Jasper template parameters order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 to ensure notifications are returned in the correct language.
 * [ODRC-101](https://openlmis.atlassian.net/browse/ODRC-101): Panel 'Number of Requisitions to be 
   created this month' on home page should not count emergency requisitions
+* [OLMIS-8231](https://openlmis.atlassian.net/browse/OLMIS-8231): Preserve Jasper template parameters order as declared in the .jrxml file.
 
 Bug fixes:
 * [MALAWISUP-7022](https://openlmis.atlassian.net/browse/MALAWISUP-7022): Fix /api/requisitions/search failing for users with many permissions (Postgres bind-parameter limit).

--- a/src/main/java/org/openlmis/requisition/domain/JasperTemplate.java
+++ b/src/main/java/org/openlmis/requisition/domain/JasperTemplate.java
@@ -25,6 +25,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Table;
@@ -57,6 +58,7 @@ public class JasperTemplate extends BaseEntity {
       fetch = FetchType.EAGER,
       orphanRemoval = true)
   @Fetch(FetchMode.SELECT)
+  @OrderBy("displayOrder ASC NULLS LAST")
   @Getter
   @Setter
   private List<JasperTemplateParameter> templateParameters;

--- a/src/main/java/org/openlmis/requisition/domain/JasperTemplateParameter.java
+++ b/src/main/java/org/openlmis/requisition/domain/JasperTemplateParameter.java
@@ -122,6 +122,11 @@ public class JasperTemplateParameter extends BaseEntity {
   @Setter
   private Boolean required;
 
+  @Column
+  @Getter
+  @Setter
+  private Integer displayOrder;
+
   @PrePersist
   @PreUpdate
   private void preSave() {
@@ -151,6 +156,7 @@ public class JasperTemplateParameter extends BaseEntity {
     jasperTemplateParameter.setSelectProperty(importer.getSelectProperty());
     jasperTemplateParameter.setDisplayProperty(importer.getDisplayProperty());
     jasperTemplateParameter.setRequired(importer.getRequired());
+    jasperTemplateParameter.setDisplayOrder(importer.getDisplayOrder());
     jasperTemplateParameter.setOptions(importer.getOptions());
     jasperTemplateParameter.setDependencies(importer.getDependencies()
         .stream()
@@ -178,6 +184,7 @@ public class JasperTemplateParameter extends BaseEntity {
     exporter.setSelectProperty(selectProperty);
     exporter.setDisplayProperty(displayProperty);
     exporter.setRequired(required);
+    exporter.setDisplayOrder(displayOrder);
     exporter.setOptions(options);
     exporter.setDependencies(dependencies
         .stream()
@@ -211,6 +218,8 @@ public class JasperTemplateParameter extends BaseEntity {
 
     void setRequired(Boolean required);
 
+    void setDisplayOrder(Integer displayOrder);
+
     void setOptions(List<String> options);
 
     void setDependencies(List<JasperTemplateParameterDependencyDto> dependencies);
@@ -240,6 +249,8 @@ public class JasperTemplateParameter extends BaseEntity {
     String getDisplayProperty();
 
     Boolean getRequired();
+
+    Integer getDisplayOrder();
 
     List<String> getOptions();
 

--- a/src/main/java/org/openlmis/requisition/dto/JasperTemplateParameterDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/JasperTemplateParameterDto.java
@@ -42,6 +42,7 @@ public class JasperTemplateParameterDto implements JasperTemplateParameter.Impor
   private String displayProperty;
   private String description;
   private Boolean required;
+  private Integer displayOrder;
   private List<String> options;
   private List<JasperTemplateParameterDependencyDto> dependencies;
 

--- a/src/main/java/org/openlmis/requisition/service/JasperTemplateService.java
+++ b/src/main/java/org/openlmis/requisition/service/JasperTemplateService.java
@@ -154,11 +154,13 @@ public class JasperTemplateService {
   private void setTemplateParameters(JasperTemplate jasperTemplate, JRParameter[] jrParameters)
       throws ReportingException {
     ArrayList<JasperTemplateParameter> parameters = new ArrayList<>();
+    int order = 0;
 
     for (JRParameter jrParameter : jrParameters) {
       if (!jrParameter.isSystemDefined() && jrParameter.isForPrompting()) {
         JasperTemplateParameter jasperTemplateParameter = createParameter(jrParameter);
         jasperTemplateParameter.setTemplate(jasperTemplate);
+        jasperTemplateParameter.setDisplayOrder(order++);
         parameters.add(jasperTemplateParameter);
       }
     }

--- a/src/main/resources/db/migration/20260521161910408__add_display_order_to_template_parameters.sql
+++ b/src/main/resources/db/migration/20260521161910408__add_display_order_to_template_parameters.sql
@@ -1,0 +1,1 @@
+ALTER TABLE template_parameters ADD COLUMN displayorder INTEGER;

--- a/src/test/java/org/openlmis/requisition/service/JasperTemplateServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperTemplateServiceTest.java
@@ -405,4 +405,64 @@ public class JasperTemplateServiceTest {
 
     assertThat(resultMap.size(), is(0));
   }
+
+  @Test
+  public void shouldSetDisplayOrderFromJrxmlDeclarationOrder() throws Exception {
+    MultipartFile file = mock(MultipartFile.class);
+    when(file.getOriginalFilename()).thenReturn(NAME_OF_FILE);
+
+    mockStatic(JasperCompileManager.class);
+    JasperReport report = mock(JasperReport.class);
+    InputStream inputStream = mock(InputStream.class);
+    when(file.getInputStream()).thenReturn(inputStream);
+
+    JRParameter first = mock(JRParameter.class);
+    JRParameter skipped = mock(JRParameter.class);
+    JRParameter second = mock(JRParameter.class);
+    JRParameter third = mock(JRParameter.class);
+    JRPropertiesMap propertiesMap = mock(JRPropertiesMap.class);
+    JRExpression jrExpression = mock(JRExpression.class);
+
+    String[] propertyNames = {DISPLAY_NAME};
+    when(report.getParameters())
+        .thenReturn(new JRParameter[]{first, skipped, second, third});
+    when(JasperCompileManager.compileReport(inputStream)).thenReturn(report);
+    when(propertiesMap.getPropertyNames()).thenReturn(propertyNames);
+    when(propertiesMap.getProperty(DISPLAY_NAME)).thenReturn(PARAM_DISPLAY_NAME);
+    when(jrExpression.getText()).thenReturn("text");
+
+    for (JRParameter p : new JRParameter[]{first, second, third}) {
+      when(p.getPropertiesMap()).thenReturn(propertiesMap);
+      when(p.getValueClassName()).thenReturn("java.lang.String");
+      when(p.isForPrompting()).thenReturn(true);
+      when(p.getDefaultValueExpression()).thenReturn(jrExpression);
+    }
+    when(first.getName()).thenReturn(PARAM1);
+    when(second.getName()).thenReturn(PARAM2);
+    when(third.getName()).thenReturn(PARAM3);
+
+    when(skipped.isSystemDefined()).thenReturn(true);
+    when(skipped.isForPrompting()).thenReturn(false);
+
+    ByteArrayOutputStream byteOutputStream = mock(ByteArrayOutputStream.class);
+    whenNew(ByteArrayOutputStream.class).withAnyArguments().thenReturn(byteOutputStream);
+    ObjectOutputStream objectOutputStream = spy(new ObjectOutputStream(byteOutputStream));
+    whenNew(ObjectOutputStream.class).withArguments(byteOutputStream)
+        .thenReturn(objectOutputStream);
+    doNothing().when(objectOutputStream).writeObject(report);
+    when(byteOutputStream.toByteArray()).thenReturn(new byte[1]);
+
+    JasperTemplate jasperTemplate = new JasperTemplate();
+
+    jasperTemplateService.validateFileAndInsertTemplate(jasperTemplate, file);
+
+    List<JasperTemplateParameter> params = jasperTemplate.getTemplateParameters();
+    assertEquals(3, params.size());
+    assertEquals(PARAM1, params.get(0).getName());
+    assertEquals(Integer.valueOf(0), params.get(0).getDisplayOrder());
+    assertEquals(PARAM2, params.get(1).getName());
+    assertEquals(Integer.valueOf(1), params.get(1).getDisplayOrder());
+    assertEquals(PARAM3, params.get(2).getName());
+    assertEquals(Integer.valueOf(2), params.get(2).getDisplayOrder());
+  }
 }


### PR DESCRIPTION
Jasper template parameters now keep the order declared in the .jrxml.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/124)
<!-- Reviewable:end -->
