### PR TITLE
OLMIS-7779: Add supplyingFacility query parameter to /api/requisitions/search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 to ensure notifications are returned in the correct language.
 * [ODRC-101](https://openlmis.atlassian.net/browse/ODRC-101): Panel 'Number of Requisitions to be 
   created this month' on home page should not count emergency requisitions
+* [OLMIS-7779](https://openlmis.atlassian.net/browse/OLMIS-7779): Add supplyingFacility query parameter to /api/requisitions/search.
 
 Bug fixes:
 * [MALAWISUP-7022](https://openlmis.atlassian.net/browse/MALAWISUP-7022): Fix /api/requisitions/search failing for users with many permissions (Postgres bind-parameter limit).

--- a/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
@@ -1016,6 +1016,7 @@ public class RequisitionRepositoryIntegrationTest
     RequisitionSearchParams searchParams = new DefaultRequisitionSearchParams(
         requisitionToCopy.getFacilityId(), requisitionToCopy.getProgramId(),
         requisitionToCopy.getProcessingPeriodId(), requisitionToCopy.getSupervisoryNodeId(),
+        null,
         requisitionToCopy.getEmergency(), null, null, null, null,
         EnumSet.of(requisitionToCopy.getStatus()));
 

--- a/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/RequisitionRepositoryIntegrationTest.java
@@ -310,6 +310,62 @@ public class RequisitionRepositoryIntegrationTest
   }
 
   @Test
+  public void testSearchRequisitionsBySupplyingFacility() {
+    UUID matchingSupplyingFacility = UUID.randomUUID();
+    UUID otherSupplyingFacility = UUID.randomUUID();
+    Requisition requisitionToCopy = requisitions.get(0);
+
+    Requisition matchingRequisition = new RequisitionDataBuilder()
+        .withFacilityId(requisitionToCopy.getFacilityId())
+        .withProgramId(requisitionToCopy.getProgramId())
+        .withStatus(requisitionToCopy.getStatus())
+        .withSupervisoryNodeId(requisitionToCopy.getSupervisoryNodeId())
+        .withSupplyingFacilityId(matchingSupplyingFacility)
+        .withTemplate(testTemplate)
+        .withNumberOfMonthsInPeriod(1)
+        .withEmergency(true)
+        .buildAsNew();
+    matchingRequisition.setStatusChanges(
+        singletonList(new StatusChangeDataBuilder()
+            .withRequisition(matchingRequisition)
+            .buildAsNew()
+        )
+    );
+    repository.save(matchingRequisition);
+
+    Requisition otherRequisition = new RequisitionDataBuilder()
+        .withFacilityId(requisitionToCopy.getFacilityId())
+        .withProgramId(requisitionToCopy.getProgramId())
+        .withStatus(requisitionToCopy.getStatus())
+        .withSupervisoryNodeId(requisitionToCopy.getSupervisoryNodeId())
+        .withSupplyingFacilityId(otherSupplyingFacility)
+        .withTemplate(testTemplate)
+        .withNumberOfMonthsInPeriod(1)
+        .withEmergency(false)
+        .buildAsNew();
+    otherRequisition.setStatusChanges(
+        singletonList(new StatusChangeDataBuilder()
+            .withRequisition(otherRequisition)
+            .buildAsNew()
+        )
+    );
+    repository.save(otherRequisition);
+
+    RequisitionSearchParams searchParams = new DefaultRequisitionSearchParamsDataBuilder()
+        .withSupplyingFacility(matchingSupplyingFacility)
+        .build();
+
+    List<Requisition> receivedRequisitions = repository
+        .searchRequisitions(searchParams, userPermissionStrings, programNodePairs, pageRequest)
+        .getContent();
+
+    assertEquals(1, receivedRequisitions.size());
+    assertEquals(
+        matchingSupplyingFacility,
+        receivedRequisitions.get(0).getSupplyingFacilityId());
+  }
+
+  @Test
   public void testSearchRequisitionsByAllParametersNull() {
     RequisitionSearchParams searchParams = new DefaultRequisitionSearchParams();
 

--- a/src/main/java/org/openlmis/requisition/repository/custom/DefaultRequisitionSearchParams.java
+++ b/src/main/java/org/openlmis/requisition/repository/custom/DefaultRequisitionSearchParams.java
@@ -36,6 +36,7 @@ public final class DefaultRequisitionSearchParams implements RequisitionSearchPa
   private UUID program;
   private UUID processingPeriod;
   private UUID supervisoryNode;
+  private UUID supplyingFacility;
 
   private Boolean emergency;
 

--- a/src/main/java/org/openlmis/requisition/repository/custom/RequisitionSearchParams.java
+++ b/src/main/java/org/openlmis/requisition/repository/custom/RequisitionSearchParams.java
@@ -31,6 +31,8 @@ public interface RequisitionSearchParams {
 
   UUID getSupervisoryNode();
 
+  UUID getSupplyingFacility();
+
   Boolean getEmergency();
 
   LocalDate getInitiatedDateFrom();

--- a/src/main/java/org/openlmis/requisition/repository/custom/impl/RequisitionRepositoryImpl.java
+++ b/src/main/java/org/openlmis/requisition/repository/custom/impl/RequisitionRepositoryImpl.java
@@ -99,6 +99,7 @@ public class RequisitionRepositoryImpl
   private static final String CREATED_DATE = "createdDate";
   private static final String PROCESSING_PERIOD_ID = "processingPeriodId";
   private static final String SUPERVISORY_NODE_ID = "supervisoryNodeId";
+  private static final String SUPPLYING_FACILITY_ID = "supplyingFacilityId";
   private static final String AUTHORIZED_DATE = "authorizedDate";
   private static final String MODIFIED_DATE = "modifiedDate";
 
@@ -476,6 +477,8 @@ public class RequisitionRepositoryImpl
         PROCESSING_PERIOD_ID, params.getProcessingPeriod());
     predicate = addEqualFilter(predicate, builder, root,
         SUPERVISORY_NODE_ID, params.getSupervisoryNode());
+    predicate = addEqualFilter(predicate, builder, root,
+        SUPPLYING_FACILITY_ID, params.getSupplyingFacility());
     predicate = addInFilter(predicate, builder, root, STATUS, params.getRequisitionStatuses());
     predicate = addEqualFilter(predicate, builder, root, EMERGENCY, params.getEmergency());
 

--- a/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
+++ b/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
@@ -347,7 +347,7 @@ public class JasperReportsViewService {
       if (facility.getActive()) {
         RequisitionSearchParams params = new DefaultRequisitionSearchParams(
             facility.getId(), program.getId(), processingPeriod.getId(),
-            null, null, null, null, null, null, validStatuses);
+            null, null, null, null, null, null, null, validStatuses);
 
         PageRequest pageRequest = PageRequest.of(Pagination.DEFAULT_PAGE_NUMBER,
             Pagination.NO_PAGINATION);

--- a/src/main/java/org/openlmis/requisition/web/QueryRequisitionSearchParams.java
+++ b/src/main/java/org/openlmis/requisition/web/QueryRequisitionSearchParams.java
@@ -45,6 +45,7 @@ final class QueryRequisitionSearchParams implements RequisitionSearchParams {
   private static final String INITIATED_DATE_TO = "initiatedDateTo";
   private static final String PROCESSING_PERIOD = "processingPeriod";
   private static final String SUPERVISORY_NODE = "supervisoryNode";
+  private static final String SUPPLYING_FACILITY = "supplyingFacility";
   private static final String REQUISITION_STATUS = "requisitionStatus";
   private static final String EMERGENCY = "emergency";
   private static final String MODIFIED_DATE_FROM = "modifiedDateFrom";
@@ -52,7 +53,7 @@ final class QueryRequisitionSearchParams implements RequisitionSearchParams {
 
   private static final List<String> ALL_PARAMETERS = asList(FACILITY, PROGRAM, INITIATED_DATE_FROM,
       INITIATED_DATE_TO, MODIFIED_DATE_FROM, MODIFIED_DATE_TO, PROCESSING_PERIOD,
-      SUPERVISORY_NODE, REQUISITION_STATUS, EMERGENCY);
+      SUPERVISORY_NODE, SUPPLYING_FACILITY, REQUISITION_STATUS, EMERGENCY);
 
   private SearchParams queryParams;
 
@@ -144,6 +145,20 @@ final class QueryRequisitionSearchParams implements RequisitionSearchParams {
       return null;
     }
     return queryParams.getUuid(SUPERVISORY_NODE);
+  }
+
+  /**
+   * Gets {@link UUID} for "supplyingFacility" key from params.
+   *
+   * @return UUID value of supplyingFacility id
+   *          or null if params doesn't contain "supplyingFacility" key.
+   */
+  @Override
+  public UUID getSupplyingFacility() {
+    if (!queryParams.containsKey(SUPPLYING_FACILITY)) {
+      return null;
+    }
+    return queryParams.getUuid(SUPPLYING_FACILITY);
   }
 
   /**

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -558,7 +558,7 @@ public class RequisitionController extends BaseRequisitionController {
 
     profiler.start("SEARCH_REQUISITIONS");
     RequisitionSearchParams params = new DefaultRequisitionSearchParams(
-        null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null,
         EnumSet.of(RequisitionStatus.SUBMITTED));
 
     Page<Requisition> submittedRequisitions = requisitionService

--- a/src/main/resources/api-definition.yaml
+++ b/src/main/resources/api-definition.yaml
@@ -743,6 +743,11 @@ resourceTypes:
                       type: string
                       required: false
                       repeat: false
+                  supplyingFacility:
+                      displayName: supplyingFacility
+                      type: string
+                      required: false
+                      repeat: false
                   requisitionStatus:
                       displayName: supervisoryNode
                       type: string

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -519,7 +519,7 @@ public class JasperReportsViewServiceTest {
         (isMissingRnR) ? Collections.emptyList() : singletonList(mockRequisition));
 
     RequisitionSearchParams params = new DefaultRequisitionSearchParams(
-        facilityId, program.getId(), period.getId(), null, null, null, null,
+        facilityId, program.getId(), period.getId(), null, null, null, null, null,
         null, null, EnumSet.of(APPROVED, RELEASED, RELEASED_WITHOUT_ORDER));
 
     when(requisitionService.searchRequisitions(eq(params), any()))

--- a/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
@@ -1297,6 +1297,7 @@ public class RequisitionServiceTest {
     RequisitionSearchParams params = new DefaultRequisitionSearchParams(
         requisition.getFacilityId(), requisition.getProgramId(),
         requisition.getProcessingPeriodId(), requisition.getSupervisoryNodeId(),
+        null,
         requisition.getEmergency(), requisition.getCreatedDate().minusDays(2).toLocalDate(),
         requisition.getCreatedDate().plusDays(2).toLocalDate(),
         requisition.getModifiedDate().minusDays(2), requisition.getModifiedDate().plusDays(2),
@@ -1359,6 +1360,7 @@ public class RequisitionServiceTest {
     final RequisitionSearchParams params = new DefaultRequisitionSearchParams(
         requisition.getFacilityId(), requisition.getProgramId(),
         requisition.getProcessingPeriodId(), requisition.getSupervisoryNodeId(),
+        null,
         requisition.getEmergency(), requisition.getCreatedDate().minusDays(2).toLocalDate(),
         requisition.getCreatedDate().plusDays(2).toLocalDate(),
         requisition.getModifiedDate().minusDays(2), requisition.getModifiedDate().plusDays(2),

--- a/src/test/java/org/openlmis/requisition/testutils/DefaultRequisitionSearchParamsDataBuilder.java
+++ b/src/test/java/org/openlmis/requisition/testutils/DefaultRequisitionSearchParamsDataBuilder.java
@@ -31,6 +31,7 @@ public class DefaultRequisitionSearchParamsDataBuilder implements
   private UUID program;
   private UUID processingPeriod;
   private UUID supervisoryNode;
+  private UUID supplyingFacility;
 
   private Boolean emergency;
 
@@ -52,6 +53,7 @@ public class DefaultRequisitionSearchParamsDataBuilder implements
         program,
         processingPeriod,
         supervisoryNode,
+        supplyingFacility,
         emergency,
         initiatedDateFrom,
         initiatedDateTo,
@@ -78,6 +80,11 @@ public class DefaultRequisitionSearchParamsDataBuilder implements
 
   public DefaultRequisitionSearchParamsDataBuilder withSupervisoryNode(UUID supervisoryNode) {
     this.supervisoryNode = supervisoryNode;
+    return this;
+  }
+
+  public DefaultRequisitionSearchParamsDataBuilder withSupplyingFacility(UUID supplyingFacility) {
+    this.supplyingFacility = supplyingFacility;
     return this;
   }
 

--- a/src/test/java/org/openlmis/requisition/web/QueryRequisitionSearchParamsTest.java
+++ b/src/test/java/org/openlmis/requisition/web/QueryRequisitionSearchParamsTest.java
@@ -53,6 +53,7 @@ public class QueryRequisitionSearchParamsTest
   private static final String INITIATED_DATE_TO = "initiatedDateTo";
   private static final String PROCESSING_PERIOD = "processingPeriod";
   private static final String SUPERVISORY_NODE = "supervisoryNode";
+  private static final String SUPPLYING_FACILITY = "supplyingFacility";
   private static final String REQUISITION_STATUS = "requisitionStatus";
   private static final String EMERGENCY = "emergency";
   private static final String MODIFIED_DATE_FROM = "modifiedDateFrom";
@@ -161,6 +162,21 @@ public class QueryRequisitionSearchParamsTest
   }
 
   @Test
+  public void shouldGetSupplyingFacilityValueFromParameters() {
+    queryMap.add(SUPPLYING_FACILITY, id.toString());
+    QueryRequisitionSearchParams params = new QueryRequisitionSearchParams(queryMap);
+
+    assertEquals(id, params.getSupplyingFacility());
+  }
+
+  @Test
+  public void shouldGetNullIfMapHasNoSupplyingFacilityProperty() {
+    QueryRequisitionSearchParams params = new QueryRequisitionSearchParams(queryMap);
+
+    assertNull(params.getSupplyingFacility());
+  }
+
+  @Test
   public void shouldGetRequisitionStatusValueFromParameters() {
     queryMap.add(REQUISITION_STATUS, RequisitionStatus.APPROVED.toString());
     queryMap.add(REQUISITION_STATUS, RequisitionStatus.AUTHORIZED.toString());
@@ -262,6 +278,7 @@ public class QueryRequisitionSearchParamsTest
   protected void prepare(ToStringVerifier<QueryRequisitionSearchParams> verifier) {
     verifier.ignore("FACILITY", "PROGRAM", "INITIATED_DATE_FROM", "INITIATED_DATE_TO",
         "MODIFIED_DATE_FROM", "MODIFIED_DATE_TO", "PROCESSING_PERIOD",
-        "SUPERVISORY_NODE", "REQUISITION_STATUS", "EMERGENCY", "ALL_PARAMETERS");
+        "SUPERVISORY_NODE", "SUPPLYING_FACILITY", "REQUISITION_STATUS", "EMERGENCY",
+        "ALL_PARAMETERS");
   }
 }


### PR DESCRIPTION
External integrations (MSupply) can now filter requisitions by supplyingFacility server-side instead of pulling all and filtering client-side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/125)
<!-- Reviewable:end -->
