### PR TITLE
OLMIS-4412: Prevent orders with all zero quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.6.0-SNAPSHOT (WIP)
 ==================
+* [OLMIS-4412](https://openlmis.atlassian.net/browse/OLMIS-4412): Release requisitions with all zero quantities without creating an order.
 
 8.5.1 / 2026-06-09
 ==================

--- a/src/integration-test/java/org/openlmis/requisition/service/RequisitionServiceIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/service/RequisitionServiceIntegrationTest.java
@@ -45,6 +45,7 @@ import com.jayway.restassured.config.RestAssuredConfig;
 import guru.nidi.ramltester.RamlDefinition;
 import guru.nidi.ramltester.RamlLoaders;
 import guru.nidi.ramltester.restassured.RestAssuredClient;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -64,6 +65,8 @@ import org.openlmis.requisition.domain.RequisitionTemplateColumn;
 import org.openlmis.requisition.domain.RequisitionTemplateColumnDataBuilder;
 import org.openlmis.requisition.domain.requisition.Requisition;
 import org.openlmis.requisition.domain.requisition.RequisitionBuilder;
+import org.openlmis.requisition.domain.requisition.RequisitionLineItem;
+import org.openlmis.requisition.domain.requisition.RequisitionLineItemDataBuilder;
 import org.openlmis.requisition.domain.requisition.RequisitionStatus;
 import org.openlmis.requisition.dto.FacilityDto;
 import org.openlmis.requisition.dto.OrderDto;
@@ -78,6 +81,7 @@ import org.openlmis.requisition.repository.RequisitionRepository;
 import org.openlmis.requisition.repository.RequisitionTemplateRepository;
 import org.openlmis.requisition.service.fulfillment.OrderFulfillmentService;
 import org.openlmis.requisition.service.referencedata.FacilityReferenceDataService;
+import org.openlmis.requisition.service.referencedata.OrderableReferenceDataService;
 import org.openlmis.requisition.service.referencedata.SupplyLineReferenceDataService;
 import org.openlmis.requisition.service.referencedata.UserFulfillmentFacilitiesReferenceDataService;
 import org.openlmis.requisition.testutils.DtoGenerator;
@@ -136,6 +140,9 @@ public class RequisitionServiceIntegrationTest {
 
   @MockBean
   private OrderFulfillmentService orderFulfillmentService;
+
+  @MockBean
+  private OrderableReferenceDataService orderableReferenceDataService;
 
   @Autowired
   private AvailableRequisitionColumnRepository availableColumnRepository;
@@ -202,6 +209,9 @@ public class RequisitionServiceIntegrationTest {
         any(UUID.class), eq(right.getId()))).willReturn(managedFacilities);
 
     doNothing().when(orderFulfillmentService).create(ordersCaptor.capture());
+
+    given(orderableReferenceDataService.findByIdentities(any()))
+        .willReturn(new ArrayList<>());
   }
 
   @Test
@@ -279,6 +289,30 @@ public class RequisitionServiceIntegrationTest {
     verify(orderFulfillmentService, times(0)).create(anyList());
   }
 
+  @Test
+  public void shouldReleaseWithoutOrderWhenAllPacksToShipAreZero() {
+    final long reqsCountBefore = requisitionRepository.count();
+    Requisition requisition = mockAndSaveRequisition(generateRequisition(0L));
+    ReleasableRequisitionBatchDto releaseDto = generateReleaseRequisitionDto(
+        Collections.singletonList(
+            getReleasableRequisitionDto(requisition)
+        ));
+
+    restAssured.given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(releaseDto)
+        .when()
+        .post(BATCH_RELEASES_URL)
+        .then()
+        .statusCode(HttpStatus.CREATED.value());
+
+    Requisition released = requisitionRepository.findById(requisition.getId()).orElse(null);
+    assertEquals(RequisitionStatus.RELEASED_WITHOUT_ORDER, released.getStatus());
+    verify(orderFulfillmentService, times(0)).create(anyList());
+    assertEquals(reqsCountBefore + 1, requisitionRepository.count());
+  }
+
   /**
    * https://openlmis.atlassian.net/browse/OLMIS-6876 indicates that there is some exception
    * after saving the requisitions and before the return statement of
@@ -318,6 +352,10 @@ public class RequisitionServiceIntegrationTest {
   }
 
   private Requisition generateRequisition() {
+    return generateRequisition(5L);
+  }
+
+  private Requisition generateRequisition(Long packsToShip) {
     Requisition requisition = RequisitionBuilder.newRequisition(UUID.randomUUID(),
         UUID.randomUUID(), false);
     requisition.setTemplate(template);
@@ -325,6 +363,13 @@ public class RequisitionServiceIntegrationTest {
     requisition.setProcessingPeriodId(UUID.randomUUID());
     requisition.setStatus(RequisitionStatus.APPROVED);
     requisition.setSupervisoryNodeId(supervisoryNodeId);
+
+    RequisitionLineItem lineItem = new RequisitionLineItemDataBuilder()
+        .withRequisition(requisition)
+        .withPacksToShip(packsToShip)
+        .withSkippedFlag(false)
+        .buildAsNew();
+    requisition.setRequisitionLineItems(new ArrayList<>(Collections.singletonList(lineItem)));
 
     return requisition;
   }

--- a/src/main/java/org/openlmis/requisition/domain/requisition/Requisition.java
+++ b/src/main/java/org/openlmis/requisition/domain/requisition/Requisition.java
@@ -817,6 +817,17 @@ public class Requisition extends BaseTimestampedEntity {
   }
 
   /**
+   * Returns true if at least one non-skipped line item has a positive packsToShip value.
+   * Returns false when all non-skipped line items have zero or null packsToShip,
+   * meaning the requisition results in a blank order with nothing to ship.
+   */
+  public boolean hasNonZeroPacksToShip() {
+    return getNonSkippedRequisitionLineItems()
+        .stream()
+        .anyMatch(line -> line.getPacksToShip() != null && line.getPacksToShip() > 0L);
+  }
+
+  /**
    * Release the requisition.
    */
   public void release(UUID releaser) {

--- a/src/main/java/org/openlmis/requisition/service/RequisitionService.java
+++ b/src/main/java/org/openlmis/requisition/service/RequisitionService.java
@@ -553,14 +553,17 @@ public class RequisitionService {
 
   /**
    * Releases the list of given requisitions as order.
+   * Requisitions with all zero packsToShip are automatically released without order
+   * and collected in autoReleasedWithoutOrder instead of the returned list.
    *
-   * @param convertToOrderDtos list of Requisitions with their supplyingDepots to be released as
-   *                           order
-   * @return list of released requisitions
+   * @param convertToOrderDtos       list of Requisitions with their supplyingDepots
+   * @param autoReleasedWithoutOrder output list populated with requisitions auto-released
+   *                                 without order (all packsToShip zero or null)
+   * @return list of requisitions released as order (non-zero packsToShip only)
    */
   private List<Requisition> releaseRequisitionsAsOrder(
           List<ReleasableRequisitionDto> convertToOrderDtos, UserDto user,
-          Boolean isLocallyFulfilled) {
+          Boolean isLocallyFulfilled, List<Requisition> autoReleasedWithoutOrder) {
     Profiler profiler = new Profiler("RELEASE_REQUISITIONS_AS_ORDER");
     profiler.setLogger(LOGGER);
 
@@ -581,6 +584,13 @@ public class RequisitionService {
               .orElseThrow(() -> new ContentNotFoundMessageException(ERROR_REQUISITION_NOT_FOUND,
                       requisitionId));
       isEligibleForConvertToOrder(loadedRequisition).throwExceptionIfHasErrors();
+
+      if (!loadedRequisition.hasNonZeroPacksToShip()) {
+        loadedRequisition.releaseWithoutOrder(authenticationHelper.getCurrentUser().getId());
+        autoReleasedWithoutOrder.add(loadedRequisition);
+        continue;
+      }
+
       loadedRequisition.release(authenticationHelper.getCurrentUser().getId());
 
       UUID facilityId = convertToOrderDto.getSupplyingDepotId();
@@ -713,6 +723,7 @@ public class RequisitionService {
 
   /**
    * Converting Requisition list to Orders.
+   * Requisitions with all zero packsToShip are automatically released without order.
    */
   public List<Requisition> convertToOrder(List<ReleasableRequisitionDto> list, UserDto user,
                                           Boolean isLocallyFulfilled) {
@@ -720,17 +731,28 @@ public class RequisitionService {
     profiler.setLogger(LOGGER);
 
     profiler.start("RELEASE_REQUISITIONS_AS_ORDER");
-    List<Requisition> releasedRequisitions =
-            releaseRequisitionsAsOrder(list, user, isLocallyFulfilled);
+    List<Requisition> autoReleasedWithoutOrder = new ArrayList<>();
+    final List<Requisition> releasedRequisitions =
+            releaseRequisitionsAsOrder(list, user, isLocallyFulfilled, autoReleasedWithoutOrder);
+
+    profiler.start("SAVE_AUTO_RELEASED_WITHOUT_ORDER");
+    for (Requisition requisition : autoReleasedWithoutOrder) {
+      requisitionRepository.save(requisition);
+      requisitionStatusProcessor.statusChange(requisition, LocaleContextHolder.getLocale());
+    }
 
     profiler.start("BUILD_ORDER_DTOS_AND_SAVE_REQUISITION");
     List<OrderDto> orders = buildOrders(releasedRequisitions, user);
 
     profiler.start("CREATE_ORDER_IN_FULFILLMENT");
-    orderFulfillmentService.create(orders);
+    if (!orders.isEmpty()) {
+      orderFulfillmentService.create(orders);
+    }
 
     profiler.stop().log();
-    return releasedRequisitions;
+    List<Requisition> allReleased = new ArrayList<>(releasedRequisitions);
+    allReleased.addAll(autoReleasedWithoutOrder);
+    return allReleased;
   }
 
   /**

--- a/src/test/java/org/openlmis/requisition/domain/requisition/RequisitionTest.java
+++ b/src/test/java/org/openlmis/requisition/domain/requisition/RequisitionTest.java
@@ -935,6 +935,70 @@ public class RequisitionTest {
   }
 
   @Test
+  public void shouldHaveNonZeroPacksToShipWhenAnyNonSkippedLineIsPositive() {
+    RequisitionLineItem zeroLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(false).withPacksToShip(0L).build();
+    RequisitionLineItem positiveLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(false).withPacksToShip(5L).build();
+
+    Requisition requisition = new RequisitionDataBuilder()
+        .addLineItem(zeroLine, false)
+        .addLineItem(positiveLine, false)
+        .build();
+
+    assertTrue(requisition.hasNonZeroPacksToShip());
+  }
+
+  @Test
+  public void shouldNotHaveNonZeroPacksToShipWhenAllNonSkippedLinesAreZero() {
+    RequisitionLineItem firstZeroLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(false).withPacksToShip(0L).build();
+    RequisitionLineItem secondZeroLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(false).withPacksToShip(0L).build();
+
+    Requisition requisition = new RequisitionDataBuilder()
+        .addLineItem(firstZeroLine, false)
+        .addLineItem(secondZeroLine, false)
+        .build();
+
+    assertFalse(requisition.hasNonZeroPacksToShip());
+  }
+
+  @Test
+  public void shouldNotHaveNonZeroPacksToShipWhenAllNonSkippedLinesAreNull() {
+    RequisitionLineItem nullLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(false).withPacksToShip(null).build();
+
+    Requisition requisition = new RequisitionDataBuilder()
+        .addLineItem(nullLine, false)
+        .build();
+
+    assertFalse(requisition.hasNonZeroPacksToShip());
+  }
+
+  @Test
+  public void shouldIgnoreSkippedLinesWhenCheckingPacksToShip() {
+    RequisitionLineItem zeroNonSkippedLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(false).withPacksToShip(0L).build();
+    RequisitionLineItem positiveSkippedLine = new RequisitionLineItemDataBuilder()
+        .withSkippedFlag(true).withPacksToShip(5L).build();
+
+    Requisition requisition = new RequisitionDataBuilder()
+        .addLineItem(zeroNonSkippedLine, false)
+        .addLineItem(positiveSkippedLine, false)
+        .build();
+
+    assertFalse(requisition.hasNonZeroPacksToShip());
+  }
+
+  @Test
+  public void shouldNotHaveNonZeroPacksToShipWhenThereAreNoLineItems() {
+    Requisition requisition = new RequisitionDataBuilder().build();
+
+    assertFalse(requisition.hasNonZeroPacksToShip());
+  }
+
+  @Test
   public void shouldUpdatePacksToShipOnSubmit() {
     // given
     long packsToShip = 5L;

--- a/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/RequisitionServiceTest.java
@@ -1711,12 +1711,47 @@ public class RequisitionServiceTest {
       requisition.setId(UUID.randomUUID());
       requisition.setSupervisoryNodeId(UUID.randomUUID());
       requisition.setSupplyingFacilityId(facility.getId());
-      requisition.setRequisitionLineItems(Lists.newArrayList());
+      RequisitionLineItem nonZeroLine = new RequisitionLineItemDataBuilder()
+          .withPacksToShip(5L)
+          .build();
+      requisition.setRequisitionLineItems(Lists.newArrayList(nonZeroLine));
       requisition.setTemplate(requisitionTemplate);
 
       when(requisitionRepository.findById(requisition.getId()))
           .thenReturn(Optional.of(requisition));
       when(facilityReferenceDataService.findOne(facility.getId())).thenReturn(facility);
+
+      result.add(new ReleasableRequisitionDto(requisition.getId(), facility.getId()));
+    }
+
+    return result;
+  }
+
+  private List<ReleasableRequisitionDto> setUpZeroPacksToShipRequisitions(
+      int amount, RequisitionStatus status) {
+    if (amount < 1) {
+      throw new IllegalArgumentException("Amount must be a positive number");
+    }
+
+    List<ReleasableRequisitionDto> result = new ArrayList<>();
+
+    for (int i = 0; i < amount; i++) {
+      FacilityDto facility = mock(FacilityDto.class);
+      when(facility.getId()).thenReturn(UUID.randomUUID());
+
+      Requisition requisition = new Requisition(UUID.randomUUID(), UUID.randomUUID(),
+          UUID.randomUUID(), status, false);
+      requisition.setId(UUID.randomUUID());
+      requisition.setSupervisoryNodeId(UUID.randomUUID());
+      requisition.setSupplyingFacilityId(facility.getId());
+      RequisitionLineItem zeroLine = new RequisitionLineItemDataBuilder()
+          .withPacksToShip(0L)
+          .build();
+      requisition.setRequisitionLineItems(Lists.newArrayList(zeroLine));
+      requisition.setTemplate(requisitionTemplate);
+
+      when(requisitionRepository.findById(requisition.getId()))
+          .thenReturn(Optional.of(requisition));
 
       result.add(new ReleasableRequisitionDto(requisition.getId(), facility.getId()));
     }
@@ -1995,6 +2030,68 @@ public class RequisitionServiceTest {
     when(facilitySupportsProgramHelper.getSupportedProgram(any(UUID.class), any(UUID.class)))
             .thenReturn(supportedProgram);
     when(supportedProgram.getSupportStartDate()).thenReturn(null);
+  }
+
+  @Test
+  public void shouldAutoReleaseWithoutOrderWhenAllPacksToShipAreZero() {
+    // given
+    List<ReleasableRequisitionDto> list = setUpZeroPacksToShipRequisitions(3, APPROVED);
+    when(fulfillmentFacilitiesReferenceDataService.getFulfillmentFacilities(
+        user.getId(), convertToOrderRight.getId())).thenReturn(emptyList());
+
+    // when
+    List<Requisition> result = requisitionService.convertToOrder(list, user);
+
+    // then
+    assertEquals(3, result.size());
+    result.forEach(req -> assertEquals(RELEASED_WITHOUT_ORDER, req.getStatus()));
+    verify(orderFulfillmentService, never()).create(any(List.class));
+  }
+
+  @Test
+  public void shouldProcessStatusChangeForZeroPacksToShipRequisitions() {
+    // given
+    List<ReleasableRequisitionDto> list = setUpZeroPacksToShipRequisitions(1, APPROVED);
+    when(fulfillmentFacilitiesReferenceDataService.getFulfillmentFacilities(
+        user.getId(), convertToOrderRight.getId())).thenReturn(emptyList());
+
+    // when
+    requisitionService.convertToOrder(list, user);
+
+    // then
+    verify(requisitionStatusProcessor).statusChange(any(Requisition.class), any(Locale.class));
+  }
+
+  @Test
+  public void shouldCreateOrderOnlyForRequisitionsWithNonZeroPacksToShip() {
+    // given: 2 non-zero + 2 zero
+    List<ReleasableRequisitionDto> nonZeroList =
+        setUpReleaseRequisitionsAsOrder(2, APPROVED);
+    List<ReleasableRequisitionDto> zeroList =
+        setUpZeroPacksToShipRequisitions(2, APPROVED);
+    List<ReleasableRequisitionDto> combined = new ArrayList<>(nonZeroList);
+    combined.addAll(zeroList);
+
+    List<FacilityDto> facilities = nonZeroList.stream()
+        .map(r -> facilityReferenceDataService.findOne(r.getSupplyingDepotId()))
+        .collect(toList());
+    when(fulfillmentFacilitiesReferenceDataService.getFulfillmentFacilities(
+        user.getId(), convertToOrderRight.getId())).thenReturn(facilities);
+    when(requisitionForConvertBuilder.getAvailableSupplyingDepots(any(UUID.class)))
+        .thenReturn(facilities);
+
+    // when
+    List<Requisition> result = requisitionService.convertToOrder(combined, user);
+
+    // then: all 4 returned
+    assertEquals(4, result.size());
+    long releasedCount = result.stream()
+        .filter(r -> RELEASED.equals(r.getStatus())).count();
+    long releasedWithoutOrderCount = result.stream()
+        .filter(r -> RELEASED_WITHOUT_ORDER.equals(r.getStatus())).count();
+    assertEquals(2, releasedCount);
+    assertEquals(2, releasedWithoutOrderCount);
+    verify(orderFulfillmentService).create(any(List.class));
   }
 
 }


### PR DESCRIPTION
Requisitions with nothing to ship are now released without creating an order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/128)
<!-- Reviewable:end -->
