### PR TITLE
OPSD-45 Add cancelled order status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Upcoming Version (WIP)
 ==================
 
 Improvements:
+* [OPSD-45](https://openlmis.atlassian.net/browse/OPSD-45): Add CANCELLED order status.
 * Stabilized consul registration and health checks
 * [ODRC-67](https://openlmis.atlassian.net/browse/ODRC-67): Added a locale cookie to communication between services
 to ensure notifications are returned in the correct language.

--- a/src/main/java/org/openlmis/requisition/dto/OrderStatus.java
+++ b/src/main/java/org/openlmis/requisition/dto/OrderStatus.java
@@ -22,5 +22,6 @@ public enum OrderStatus {
   RECEIVED,
   TRANSFER_FAILED,
   IN_ROUTE,
-  READY_TO_PACK
+  READY_TO_PACK,
+  CANCELLED
 }


### PR DESCRIPTION
Adds the cancelled value to the order status so cancelled orders deserialize without error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/129)
<!-- Reviewable:end -->
