### PR TITLE
OLMIS-8176: Add pack size column to requisition print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.6.0-SNAPSHOT (WIP)
 ==================
+* [OLMIS-8176](https://openlmis.atlassian.net/browse/OLMIS-8176): Added a Pack Size column to the requisition printed report.
 
 8.5.1 / 2026-06-09
 ==================

--- a/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
+++ b/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import net.sf.jasperreports.engine.JRBand;
 import net.sf.jasperreports.engine.design.JRDesignTextField;
 import org.openlmis.requisition.domain.RequisitionTemplateColumn;
@@ -36,6 +37,10 @@ import org.openlmis.requisition.domain.requisition.RequisitionStatus;
 import org.springframework.context.i18n.LocaleContextHolder;
 
 public final class ReportUtils {
+  private static final String FULL_PRODUCT_NAME_COLUMN = "orderable.fullProductName";
+  // key of the static Pack size column in requisitionLines.jrxml (not a template column)
+  private static final String PACK_SIZE_COLUMN = "packSize";
+
   private ReportUtils() {
     throw new UnsupportedOperationException();
   }
@@ -94,6 +99,8 @@ public final class ReportUtils {
   public static void customizeBandWithTemplateFields(
       JRBand band, Map<String, RequisitionTemplateColumn> columns, int width, int margin) {
     List<String> foundTemplateKeys = columns.keySet().stream()
+        .flatMap(key -> FULL_PRODUCT_NAME_COLUMN.equals(key)
+            ? Stream.of(key, PACK_SIZE_COLUMN) : Stream.of(key))
         .filter(key -> band.getElementByKey(key) != null)
         .collect(Collectors.toList());
     List<JRDesignTextField> foundColumns = band.getChildren().stream()
@@ -118,16 +125,16 @@ public final class ReportUtils {
 
   private static double getWidthMultipier(int width, int margin, List<String> foundTemplateKeys,
                                           List<JRDesignTextField> foundColumns) {
-    int toFill = 0;
+    int keptTotal = 0;
     for (JRDesignTextField field : foundColumns) {
-      if (!foundTemplateKeys.contains(field.getKey())) {
-        toFill += field.getWidth();
+      if (foundTemplateKeys.contains(field.getKey())) {
+        keptTotal += field.getWidth();
       }
     }
 
-    if (toFill != 0) {
+    if (keptTotal != 0) {
       int lineWidth = width - 2 * margin;
-      return (double)lineWidth / (lineWidth - toFill);
+      return (double) lineWidth / keptTotal;
     }
     return 1;
   }

--- a/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
+++ b/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
@@ -134,6 +134,9 @@ public final class ReportUtils {
 
     if (keptTotal != 0) {
       int lineWidth = width - 2 * margin;
+      // Scale the kept columns to fill the line width. The injected static pack size column
+      // breaks the old assumption that every column sums to the line width, so we divide by the
+      // kept total instead of (line width - removed width).
       return (double) lineWidth / keptTotal;
     }
     return 1;

--- a/src/main/resources/jasperTemplates/requisitionLines.jrxml
+++ b/src/main/resources/jasperTemplates/requisitionLines.jrxml
@@ -687,7 +687,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{orderable}.getNetContent()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[String.valueOf($F{orderable}.getNetContent())]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="orderable.productCode" x="9" y="0" width="31" height="25" uuid="364650f2-c5ab-49b6-b74a-89aa733eeda5">

--- a/src/main/resources/jasperTemplates/requisitionLines.jrxml
+++ b/src/main/resources/jasperTemplates/requisitionLines.jrxml
@@ -135,7 +135,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Pack Size"]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.packSize}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="orderable.productCode" mode="Opaque" x="9" y="0" width="31" height="35" backcolor="#CCCCCC" uuid="aa050bad-b263-43fa-8d5e-9c9b506f2260">
@@ -683,7 +683,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[String.valueOf($F{orderable}.getNetContent())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{netContent} == null ? "" : String.valueOf($F{netContent}.longValue())]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="orderable.productCode" x="9" y="0" width="31" height="25" uuid="364650f2-c5ab-49b6-b74a-89aa733eeda5">

--- a/src/main/resources/jasperTemplates/requisitionLines.jrxml
+++ b/src/main/resources/jasperTemplates/requisitionLines.jrxml
@@ -129,6 +129,19 @@
 				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.fullProductName").getLabel()]]></textFieldExpression>
 			</textField>
 			<textField>
+				<reportElement key="packSize" mode="Opaque" x="100" y="0" width="34" height="35" backcolor="#CCCCCC" uuid="b3b11473-3619-446a-8526-d0a285a82b4b"/>
+				<box padding="2">
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA["Pack Size"]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement key="orderable.productCode" mode="Opaque" x="9" y="0" width="31" height="35" backcolor="#CCCCCC" uuid="aa050bad-b263-43fa-8d5e-9c9b506f2260">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.width" value="px"/>
@@ -662,6 +675,19 @@
 					<font size="6"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.fullProductName").getIsDisplayed() ? $F{orderable}.getFullProductName() : null]]></textFieldExpression>
+			</textField>
+			<textField isBlankWhenNull="true">
+				<reportElement key="packSize" x="100" y="0" width="34" height="25" uuid="29e9d253-e341-4e03-b54b-ce9eecb6a861"/>
+				<box padding="2">
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement>
+					<font size="6"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{orderable}.getNetContent()]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="orderable.productCode" x="9" y="0" width="31" height="25" uuid="364650f2-c5ab-49b6-b74a-89aa733eeda5">

--- a/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
+++ b/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
@@ -231,6 +231,32 @@ public class ReportUtilsTest {
     assertEquals(FIELD_THREE_WIDTH, fieldThree.getWidth(), DELTA);
   }
 
+  @Test
+  public void shouldKeepPackSizeColumnAfterProductNameWhenNotInTemplate() {
+    // given
+    JRBand jrBand = mock(JRBand.class);
+    JRDesignTextField productName = getField("orderable.fullProductName", FIELD_ONE_WIDTH);
+    JRDesignTextField packSize = getField("packSize", FIELD_THREE_WIDTH);
+
+    LinkedList<JRChild> children = new LinkedList<>(Arrays.asList(productName, packSize));
+    when(jrBand.getChildren()).thenReturn(children);
+    when(jrBand.getElementByKey("orderable.fullProductName")).thenReturn(productName);
+    when(jrBand.getElementByKey("packSize")).thenReturn(packSize);
+
+    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
+    RequisitionTemplateColumn productNameColumn = mock(RequisitionTemplateColumn.class);
+    stubDisplay(productNameColumn, 1);
+    columns.put("orderable.fullProductName", productNameColumn);
+
+    // when
+    ReportUtils.customizeBandWithTemplateFields(jrBand, columns, WIDTH, MARGIN);
+
+    // then
+    assertTrue(children.contains(packSize));
+    assertEquals(MARGIN, productName.getX());
+    assertEquals(productName.getX() + productName.getWidth(), packSize.getX());
+  }
+
   private void stubDisplay(RequisitionTemplateColumn column, int displayOrder) {
     when(column.getDisplayOrder()).thenReturn(displayOrder);
     when(column.getIsDisplayed()).thenReturn(true);

--- a/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
+++ b/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
@@ -18,6 +18,7 @@ package org.openlmis.requisition.utils;
 import static net.sf.jasperreports.engine.JRParameter.REPORT_LOCALE;
 import static net.sf.jasperreports.engine.JRParameter.REPORT_RESOURCE_BUNDLE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -55,6 +56,12 @@ public class ReportUtilsTest {
   private static final int WIDTH_WITHOUT_MARGIN = 26;
   private static final int WIDTH = 30;
   private static final int MARGIN = 2;
+
+  // two of these columns sum to 40, which overflows WIDTH_WITHOUT_MARGIN (26) and forces a shrink
+  private static final int WIDE_FIELD_WIDTH = 20;
+
+  private static final String PRODUCT_NAME_KEY = "orderable.fullProductName";
+  private static final String PACK_SIZE_KEY = "packSize";
 
   private static final int DELTA = 1000;
 
@@ -235,18 +242,18 @@ public class ReportUtilsTest {
   public void shouldKeepPackSizeColumnAfterProductNameWhenProductNameInTemplate() {
     // given
     JRBand jrBand = mock(JRBand.class);
-    JRDesignTextField productName = getField("orderable.fullProductName", FIELD_ONE_WIDTH);
-    JRDesignTextField packSize = getField("packSize", FIELD_THREE_WIDTH);
+    JRDesignTextField productName = getField(PRODUCT_NAME_KEY, FIELD_ONE_WIDTH);
+    JRDesignTextField packSize = getField(PACK_SIZE_KEY, FIELD_THREE_WIDTH);
 
     LinkedList<JRChild> children = new LinkedList<>(Arrays.asList(productName, packSize));
     when(jrBand.getChildren()).thenReturn(children);
-    when(jrBand.getElementByKey("orderable.fullProductName")).thenReturn(productName);
-    when(jrBand.getElementByKey("packSize")).thenReturn(packSize);
+    when(jrBand.getElementByKey(PRODUCT_NAME_KEY)).thenReturn(productName);
+    when(jrBand.getElementByKey(PACK_SIZE_KEY)).thenReturn(packSize);
 
     Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
     RequisitionTemplateColumn productNameColumn = mock(RequisitionTemplateColumn.class);
     stubDisplay(productNameColumn, 1);
-    columns.put("orderable.fullProductName", productNameColumn);
+    columns.put(PRODUCT_NAME_KEY, productNameColumn);
 
     // when
     ReportUtils.customizeBandWithTemplateFields(jrBand, columns, WIDTH, MARGIN);
@@ -255,6 +262,59 @@ public class ReportUtilsTest {
     assertTrue(children.contains(packSize));
     assertEquals(MARGIN, productName.getX());
     assertEquals(productName.getX() + productName.getWidth(), packSize.getX());
+  }
+
+  @Test
+  public void shouldRescaleProductNameAndPackSizeWidthsToFillLine() {
+    // given
+    JRBand jrBand = mock(JRBand.class);
+    JRDesignTextField productName = getField(PRODUCT_NAME_KEY, WIDE_FIELD_WIDTH);
+    JRDesignTextField packSize = getField(PACK_SIZE_KEY, WIDE_FIELD_WIDTH);
+
+    LinkedList<JRChild> children = new LinkedList<>(Arrays.asList(productName, packSize));
+    when(jrBand.getChildren()).thenReturn(children);
+    when(jrBand.getElementByKey(PRODUCT_NAME_KEY)).thenReturn(productName);
+    when(jrBand.getElementByKey(PACK_SIZE_KEY)).thenReturn(packSize);
+
+    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
+    RequisitionTemplateColumn productNameColumn = mock(RequisitionTemplateColumn.class);
+    stubDisplay(productNameColumn, 1);
+    columns.put(PRODUCT_NAME_KEY, productNameColumn);
+
+    // when
+    ReportUtils.customizeBandWithTemplateFields(jrBand, columns, WIDTH, MARGIN);
+
+    // then
+    assertEquals(WIDTH_WITHOUT_MARGIN, productName.getWidth() + packSize.getWidth());
+    assertTrue(productName.getWidth() < WIDE_FIELD_WIDTH);
+    assertTrue(packSize.getWidth() < WIDE_FIELD_WIDTH);
+    assertEquals(MARGIN, productName.getX());
+    assertEquals(productName.getX() + productName.getWidth(), packSize.getX());
+  }
+
+  @Test
+  public void shouldRemovePackSizeColumnWhenProductNameNotInTemplate() {
+    // given
+    JRBand jrBand = mock(JRBand.class);
+    JRDesignTextField consumption = getField(ADJUSTED_CONSUMPTION, FIELD_ONE_WIDTH);
+    JRDesignTextField packSize = getField(PACK_SIZE_KEY, FIELD_THREE_WIDTH);
+
+    LinkedList<JRChild> children = new LinkedList<>(Arrays.asList(consumption, packSize));
+    when(jrBand.getChildren()).thenReturn(children);
+    when(jrBand.getElementByKey(ADJUSTED_CONSUMPTION)).thenReturn(consumption);
+    when(jrBand.getElementByKey(PACK_SIZE_KEY)).thenReturn(packSize);
+
+    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
+    RequisitionTemplateColumn consumptionColumn = mock(RequisitionTemplateColumn.class);
+    stubDisplay(consumptionColumn, 1);
+    columns.put(ADJUSTED_CONSUMPTION, consumptionColumn);
+
+    // when
+    ReportUtils.customizeBandWithTemplateFields(jrBand, columns, WIDTH, MARGIN);
+
+    // then
+    assertFalse(children.contains(packSize));
+    assertTrue(children.contains(consumption));
   }
 
   private void stubDisplay(RequisitionTemplateColumn column, int displayOrder) {

--- a/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
+++ b/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
@@ -232,7 +232,7 @@ public class ReportUtilsTest {
   }
 
   @Test
-  public void shouldKeepPackSizeColumnAfterProductNameWhenNotInTemplate() {
+  public void shouldKeepPackSizeColumnAfterProductNameWhenProductNameInTemplate() {
     // given
     JRBand jrBand = mock(JRBand.class);
     JRDesignTextField productName = getField("orderable.fullProductName", FIELD_ONE_WIDTH);


### PR DESCRIPTION
Adds a Pack Size column (product net content) to the requisition printed report.

- requisitionLines.jrxml: a static Pack Size column right after the product name.
- ReportUtils: keeps that static column in the template-driven layout and rescales the other columns so the row still fits the page width.

Also fixes a fill-time crash found while testing: the Pack Size cell passed the raw numeric net content into a String text field, which throws when the report renders. It is now wrapped in String.valueOf, the same way the other numeric cells in this report already do.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/130)
<!-- Reviewable:end -->
