### PR TITLE
OPSD-98: Register supplyingFacilityStockOnHand as a template column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
 Improvements:
+* [OPSD-99](https://openlmis.atlassian.net/browse/OPSD-99): Return supplying-facility stock on hand and supplying-facility metadata in GET /api/requisitions/{id} for approval-eligible requisitions, gated by the supplyingFacilityStockOnHand template column and STOCK_CARDS_VIEW at the supplying facility (display-only; the approve endpoint is unchanged).
 * [OPSD-98](https://openlmis.atlassian.net/browse/OPSD-98): Registered the read-only supplyingFacilityStockOnHand requisition-template column (disabled by default, kept out of generated requisition reports).
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Migrated the SonarCloud analysis to Java 21 by running it through the SonarQube scan action instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
 Improvements:
+* [OPSD-98](https://openlmis.atlassian.net/browse/OPSD-98): Registered the read-only supplyingFacilityStockOnHand requisition-template column (disabled by default, kept out of generated requisition reports).
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Migrated the SonarCloud analysis to Java 21 by running it through the SonarQube scan action instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).
 

--- a/src/integration-test/java/org/openlmis/requisition/repository/AvailableRequisitionColumnRepositoryIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/repository/AvailableRequisitionColumnRepositoryIntegrationTest.java
@@ -16,6 +16,8 @@
 package org.openlmis.requisition.repository;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.openlmis.requisition.domain.requisition.RequisitionLineItem.TOTAL_CONSUMED_QUANTITY;
 import static org.openlmis.requisition.domain.requisition.RequisitionLineItem.TOTAL_LOSSES_AND_ADJUSTMENTS;
@@ -26,6 +28,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.Test;
 import org.openlmis.requisition.domain.AvailableRequisitionColumn;
+import org.openlmis.requisition.domain.ColumnType;
+import org.openlmis.requisition.domain.SourceType;
 import org.openlmis.requisition.testutils.AvailableRequisitionColumnDataBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.CrudRepository;
@@ -58,5 +62,18 @@ public class AvailableRequisitionColumnRepositoryIntegrationTest
     assertTrue(columnNames.contains(TOTAL_CONSUMED_QUANTITY));
     assertTrue(columnNames.contains(TOTAL_LOSSES_AND_ADJUSTMENTS));
     assertTrue(columnNames.contains(TOTAL_RECEIVED_QUANTITY));
+  }
+
+  @Test
+  public void shouldHaveSupplyingFacilityStockOnHandColumnRegistered() {
+    AvailableRequisitionColumn column = repository.findByName("supplyingFacilityStockOnHand");
+
+    assertNotNull(column);
+    assertEquals("SF", column.getIndicator());
+    assertEquals(ColumnType.NUMERIC, column.getColumnType());
+    assertFalse(column.getMandatory());
+    assertFalse(column.getSupportsTag());
+    assertEquals(1, column.getSources().size());
+    assertTrue(column.getSources().contains(SourceType.SUPPLYING_FACILITY_STOCK));
   }
 }

--- a/src/main/java/org/openlmis/requisition/domain/SourceType.java
+++ b/src/main/java/org/openlmis/requisition/domain/SourceType.java
@@ -20,7 +20,12 @@ public enum SourceType {
   CALCULATED,
   REFERENCE_DATA,
   STOCK_CARDS,
-  PREVIOUS_REQUISITION;
+  PREVIOUS_REQUISITION,
+  // Read-only value derived from the supplying facility's stock and computed at read time. It is
+  // deliberately neither a reference nor a stock source: it has no backing requisition line-item
+  // property, so treating it as a stock source would make the line-item stock invariants reflect on
+  // a non-existent property. Must stay LAST - columns_maps.source is persisted by enum ordinal.
+  SUPPLYING_FACILITY_STOCK;
 
   public boolean isReferenceSource() {
     return REFERENCE_DATA.equals(this) || STOCK_CARDS.equals(this);

--- a/src/main/java/org/openlmis/requisition/domain/SourceType.java
+++ b/src/main/java/org/openlmis/requisition/domain/SourceType.java
@@ -16,15 +16,17 @@
 package org.openlmis.requisition.domain;
 
 public enum SourceType {
+  // Persisted by ORDINAL in columns_maps.source (RequisitionTemplateColumn.source has no
+  // @Enumerated), so existing constants must keep their position: only append new values,
+  // never reorder or insert.
   USER_INPUT,
   CALCULATED,
   REFERENCE_DATA,
   STOCK_CARDS,
   PREVIOUS_REQUISITION,
-  // Read-only value derived from the supplying facility's stock and computed at read time. It is
-  // deliberately neither a reference nor a stock source: it has no backing requisition line-item
-  // property, so treating it as a stock source would make the line-item stock invariants reflect on
-  // a non-existent property. Must stay LAST - columns_maps.source is persisted by enum ordinal.
+  // Ordinal 5, written as source = 5 by the requisition-template migration. It is deliberately
+  // neither a reference nor a stock source: it has no backing line-item property, so treating it
+  // as a stock source would make the line-item stock invariants reflect on a missing property.
   SUPPLYING_FACILITY_STOCK;
 
   public boolean isReferenceSource() {

--- a/src/main/java/org/openlmis/requisition/dto/BaseRequisitionDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/BaseRequisitionDto.java
@@ -101,6 +101,17 @@ public abstract class BaseRequisitionDto
   @Setter
   private Map<String, Object> extraData;
 
+  // Supplying-facility stock visibility (populated only for approval-eligible requisitions when the
+  // template column is enabled and the caller is authorised; see SupplyingFacilityStockService).
+  // Distinct from the single supplyingFacility UUID above (convert-to-order depot).
+  @Getter
+  @Setter
+  private List<SupplyingFacilityDto> supplyingFacilities;
+
+  @Getter
+  @Setter
+  private Boolean supplyingFacilityAccessDenied;
+
   @Override
   public List<RequisitionLineItem.Importer> getRequisitionLineItems() {
     return new ArrayList<>(

--- a/src/main/java/org/openlmis/requisition/dto/BaseRequisitionLineItemDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/BaseRequisitionLineItemDto.java
@@ -76,6 +76,10 @@ public abstract class BaseRequisitionLineItemDto extends BaseDto
   private Integer convertedQuantityToIssue;
   private Integer dosesPerPatient;
 
+  // Read-only supplying-facility stock on hand for this orderable, computed at read time during
+  // approval (see SupplyingFacilityStockService). Not persisted; not on the line-item Importer.
+  private Integer supplyingFacilityStockOnHand;
+
   @JsonProperty
   private List<StockAdjustmentDto> stockAdjustments = new ArrayList<>();
 

--- a/src/main/java/org/openlmis/requisition/dto/SupplyingFacilityDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/SupplyingFacilityDto.java
@@ -1,0 +1,41 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Lean representation of a supplying facility ({@code id}, {@code code}, {@code name}) exposed on
+ * the requisition read payload during approval. Distinct from the requisition-level
+ * {@code supplyingFacility} UUID, which denotes the convert-to-order depot.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class SupplyingFacilityDto {
+  private UUID id;
+  private String code;
+  private String name;
+}

--- a/src/main/java/org/openlmis/requisition/repository/AvailableRequisitionColumnRepository.java
+++ b/src/main/java/org/openlmis/requisition/repository/AvailableRequisitionColumnRepository.java
@@ -24,4 +24,6 @@ public interface AvailableRequisitionColumnRepository
     extends PagingAndSortingRepository<AvailableRequisitionColumn, UUID> {
 
   List<AvailableRequisitionColumn> findBySupportsTag(Boolean supportsTag);
+
+  AvailableRequisitionColumn findByName(String name);
 }

--- a/src/main/java/org/openlmis/requisition/service/PermissionService.java
+++ b/src/main/java/org/openlmis/requisition/service/PermissionService.java
@@ -54,6 +54,8 @@ public class PermissionService {
 
   public static final String ORDERS_EDIT = "ORDERS_EDIT";
 
+  public static final String STOCK_CARDS_VIEW = "STOCK_CARDS_VIEW";
+
   @Autowired
   private RightAssignmentPermissionValidator rightAssignmentPermissionValidator;
 
@@ -279,6 +281,19 @@ public class PermissionService {
     return ValidationResult
         .noPermission(ERROR_NO_FOLLOWING_PERMISSION_FOR_REQUISITION_UPDATE,
             status.toString(), rightName);
+  }
+
+  /**
+   * Checks whether the current user may view stock cards at the given facility. Used by the
+   * supplying-facility stock-on-hand feature to gate display of the value, not the cross-service
+   * stock fetch itself (which uses the service account). Evaluated under the ambient user token.
+   *
+   * @param facilityId the resolved supplying facility to evaluate the right at
+   * @param programId  the requisition program
+   * @return success when the user holds STOCK_CARDS_VIEW at the facility, no-permission otherwise
+   */
+  public ValidationResult canViewStockCards(UUID facilityId, UUID programId) {
+    return checkRight(STOCK_CARDS_VIEW, facilityId, programId);
   }
 
   private ValidationResult checkRight(String rightName) {

--- a/src/main/java/org/openlmis/requisition/service/SupplyingFacilityStockService.java
+++ b/src/main/java/org/openlmis/requisition/service/SupplyingFacilityStockService.java
@@ -1,0 +1,129 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.domain.requisition.RequisitionLineItem;
+import org.openlmis.requisition.dto.BaseRequisitionDto;
+import org.openlmis.requisition.dto.BaseRequisitionLineItemDto;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.SupplyingFacilityDto;
+import org.openlmis.requisition.dto.VersionIdentityDto;
+import org.openlmis.requisition.exception.AuthenticationMessageException;
+import org.openlmis.requisition.service.referencedata.SupplyingFacilityResolver;
+import org.openlmis.requisition.service.stockmanagement.SupplyingFacilitySohAggregator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Populates supplying-facility stock-on-hand fields on a requisition read DTO during approval. The
+ * whole flow is gated (approval-eligible status, template column enabled, caller can approve, and
+ * the caller holds STOCK_CARDS_VIEW at the resolved supplying facility); unless every gate passes
+ * the DTO is left untouched. Display-only: the approve endpoint is never involved.
+ */
+@Service
+@RequiredArgsConstructor
+public class SupplyingFacilityStockService {
+
+  static final String COLUMN = "supplyingFacilityStockOnHand";
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SupplyingFacilityStockService.class);
+
+  private final PermissionService permissionService;
+  private final SupplyingFacilityResolver resolver;
+  private final SupplyingFacilitySohAggregator aggregator;
+
+  /**
+   * Adds supplying-facility metadata and per-line stock on hand to the DTO when the requisition is
+   * approval-eligible, the template column is enabled and the caller is authorised. A no-op
+   * otherwise, so payloads stay unchanged for every non-approval read.
+   *
+   * @param requisition the requisition being read
+   * @param dto         the response DTO to enrich in place
+   */
+  public void enrich(Requisition requisition, BaseRequisitionDto dto) {
+    if (!requisition.isApprovable()
+        || !requisition.getTemplate().isColumnInTemplateAndDisplayed(COLUMN)) {
+      return;
+    }
+    // Receiving-side roles must not see supplying-facility stock and get no notification.
+    if (!permissionService.canApproveRequisition(requisition).isSuccess()) {
+      return;
+    }
+    List<FacilityDto> facilities = resolver.resolve(requisition);
+    if (facilities.isEmpty()) {
+      return;
+    }
+    if (!hasStockCardsView(facilities, requisition.getProgramId())) {
+      dto.setSupplyingFacilityAccessDenied(true);
+      return;
+    }
+
+    dto.setSupplyingFacilities(toSupplyingFacilityDtos(facilities));
+    dto.setSupplyingFacilityAccessDenied(false);
+
+    List<RequisitionLineItem.Importer> lineItems = dto.getRequisitionLineItems();
+    aggregator.aggregate(requisition.getProgramId(), facilities, orderableIds(lineItems))
+        .ifPresent(byOrderable -> populateLineItemStockOnHand(lineItems, byOrderable));
+  }
+
+  private boolean hasStockCardsView(List<FacilityDto> facilities, UUID programId) {
+    try {
+      return facilities.stream().allMatch(facility ->
+          permissionService.canViewStockCards(facility.getId(), programId).isSuccess());
+    } catch (AuthenticationMessageException ex) {
+      // STOCK_CARDS_VIEW is not registered in this deployment; degrade gracefully rather than 500.
+      LOGGER.warn("Could not evaluate STOCK_CARDS_VIEW; supplying-facility stock not shown", ex);
+      return false;
+    }
+  }
+
+  private List<SupplyingFacilityDto> toSupplyingFacilityDtos(List<FacilityDto> facilities) {
+    return facilities.stream()
+        .map(facility ->
+            new SupplyingFacilityDto(facility.getId(), facility.getCode(), facility.getName()))
+        .collect(Collectors.toList());
+  }
+
+  private Set<UUID> orderableIds(List<RequisitionLineItem.Importer> lineItems) {
+    return lineItems.stream()
+        .map(RequisitionLineItem.Importer::getOrderableIdentity)
+        .filter(Objects::nonNull)
+        .map(VersionIdentityDto::getId)
+        .collect(Collectors.toSet());
+  }
+
+  private void populateLineItemStockOnHand(List<RequisitionLineItem.Importer> lineItems,
+      Map<UUID, Integer> byOrderable) {
+    for (RequisitionLineItem.Importer importer : lineItems) {
+      VersionIdentityDto orderable = importer.getOrderableIdentity();
+      if (orderable != null) {
+        // The only Importer implementor is BaseRequisitionLineItemDto, which owns the setter.
+        BaseRequisitionLineItemDto line = (BaseRequisitionLineItemDto) importer;
+        line.setSupplyingFacilityStockOnHand(byOrderable.get(orderable.getId()));
+      }
+    }
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolver.java
+++ b/src/main/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolver.java
@@ -1,0 +1,62 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.referencedata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.SupplyLineDto;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the distinct supplying facilities for a requisition using the existing SupplyLine
+ * configuration for its (program, current supervisory node). Internal only; not exposed over HTTP.
+ */
+@Component
+@RequiredArgsConstructor
+public class SupplyingFacilityResolver {
+
+  private final SupplyLineReferenceDataService supplyLineReferenceDataService;
+
+  /**
+   * Resolves the distinct supplying facilities for the requisition. Returns an empty list when the
+   * requisition has no supervisory node or no matching SupplyLine (i.e. "not configured").
+   *
+   * @param requisition the requisition being read
+   * @return distinct supplying facilities, in SupplyLine order
+   */
+  public List<FacilityDto> resolve(Requisition requisition) {
+    if (requisition.getSupervisoryNodeId() == null) {
+      return Collections.emptyList();
+    }
+
+    Map<UUID, FacilityDto> distinctById = new LinkedHashMap<>();
+    for (SupplyLineDto supplyLine : supplyLineReferenceDataService
+        .search(requisition.getProgramId(), requisition.getSupervisoryNodeId())) {
+      FacilityDto facility = supplyLine.getSupplyingFacility();
+      if (facility != null) {
+        distinctById.putIfAbsent(facility.getId(), facility);
+      }
+    }
+    return new ArrayList<>(distinctById.values());
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregator.java
+++ b/src/main/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregator.java
@@ -1,0 +1,84 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.stockmanagement;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.stockmanagement.StockCardSummaryDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fetches supplying-facility stock on hand and aggregates it per orderable: sum across each
+ * facility's lots, then maximum across facilities (the largest single depot that could supply the
+ * line). The cross-service call uses the service account, so no facility-scoped token is needed.
+ * Any single lookup failure yields no values at all, so approvers never see an under-counted total.
+ */
+@Component
+@RequiredArgsConstructor
+public class SupplyingFacilitySohAggregator {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SupplyingFacilitySohAggregator.class);
+
+  private final StockCardSummariesStockManagementService stockCardSummariesService;
+
+  /**
+   * Aggregates supplying-facility SOH per orderable.
+   *
+   * @return {@code Optional.empty()} when any per-facility lookup failed (all SOH treated as null);
+   *         otherwise a map of orderable id to the max-across-facilities of the per-facility lot
+   *         sums. An orderable absent from the map has no stock card (line SOH is null), which is
+   *         distinct from a mapped value of {@code 0} (a card exists but is empty).
+   */
+  public Optional<Map<UUID, Integer>> aggregate(UUID programId, List<FacilityDto> facilities,
+      Set<UUID> orderableIds) {
+    if (facilities.isEmpty() || orderableIds.isEmpty()) {
+      return Optional.of(Collections.emptyMap());
+    }
+
+    Map<UUID, Integer> byOrderable = new HashMap<>();
+    for (FacilityDto facility : facilities) {
+      try {
+        perFacilitySoh(programId, facility.getId(), orderableIds)
+            .forEach((orderableId, soh) -> byOrderable.merge(orderableId, soh, Integer::max));
+      } catch (RuntimeException ex) {
+        LOGGER.warn("Supplying-facility stock-on-hand lookup failed for facility {}",
+            facility.getId(), ex);
+        return Optional.empty();
+      }
+    }
+    return Optional.of(byOrderable);
+  }
+
+  private Map<UUID, Integer> perFacilitySoh(UUID programId, UUID facilityId,
+      Set<UUID> orderableIds) {
+    return stockCardSummariesService.search(programId, facilityId, orderableIds, null)
+        .stream()
+        .filter(card -> card.getOrderable() != null && card.getStockOnHand() != null)
+        .collect(Collectors.groupingBy(card -> card.getOrderable().getId(),
+            Collectors.summingInt(StockCardSummaryDto::getStockOnHand)));
+  }
+}

--- a/src/main/java/org/openlmis/requisition/web/BatchRequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/BatchRequisitionController.java
@@ -23,7 +23,9 @@ import static org.openlmis.requisition.i18n.MessageKeys.ERROR_NO_FOLLOWING_PERMI
 
 import com.google.common.collect.Lists;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -95,6 +97,16 @@ public class BatchRequisitionController extends BaseRequisitionController {
 
   private static final XLogger XLOGGER = XLoggerFactory.getXLogger(
       BatchRequisitionController.class);
+
+  // Columns that do not map to a settable RequisitionLineItem property. They are skipped when
+  // nulling non-displayed calculated fields, otherwise the reflective setter would fail on them.
+  private static final Set<String> COLUMNS_WITHOUT_LINE_ITEM_FIELD = Collections.unmodifiableSet(
+      new HashSet<>(Arrays.asList(
+          "pricePerPack",
+          "orderable.dispensable.displayUnit",
+          "orderable.productCode",
+          "dosesPerPatient",
+          "supplyingFacilityStockOnHand")));
 
   @Autowired
   private MessageService messageService;
@@ -511,10 +523,7 @@ public class BatchRequisitionController extends BaseRequisitionController {
   }
 
   private boolean getColumnNameConditions(RequisitionTemplateColumn column) {
-    return !("pricePerPack".equals(column.getName())
-            || "orderable.dispensable.displayUnit".equals(column.getName())
-            || "orderable.productCode".equals(column.getName())
-            || "dosesPerPatient".equals(column.getName()));
+    return !COLUMNS_WITHOUT_LINE_ITEM_FIELD.contains(column.getName());
   }
 
   private void setNullForField(RequisitionLineItem lineItem, RequisitionTemplateColumn column) {

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -51,6 +51,7 @@ import org.openlmis.requisition.i18n.MessageKeys;
 import org.openlmis.requisition.repository.custom.DefaultRequisitionSearchParams;
 import org.openlmis.requisition.repository.custom.RequisitionSearchParams;
 import org.openlmis.requisition.service.RequisitionStatusNotifier;
+import org.openlmis.requisition.service.SupplyingFacilityStockService;
 import org.openlmis.requisition.service.referencedata.SupervisoryNodeReferenceDataService;
 import org.openlmis.requisition.utils.Message;
 import org.openlmis.requisition.utils.Pagination;
@@ -85,6 +86,9 @@ public class RequisitionController extends BaseRequisitionController {
 
   @Autowired
   private RequisitionStatusNotifier requisitionStatusNotifier;
+
+  @Autowired
+  private SupplyingFacilityStockService supplyingFacilityStockService;
 
   @Autowired
   private SupervisoryNodeReferenceDataService supervisoryNodeService;
@@ -312,6 +316,9 @@ public class RequisitionController extends BaseRequisitionController {
         findProgram(requisition.getProgramId(), profiler),
         null
     );
+
+    profiler.start("POPULATE_SUPPLYING_FACILITY_SOH");
+    supplyingFacilityStockService.enrich(requisition, requisitionDto);
 
     stopProfiler(profiler, requisitionDto);
 

--- a/src/main/resources/db/migration/20260804111611000__add_supplying_facility_stock_on_hand_column.sql
+++ b/src/main/resources/db/migration/20260804111611000__add_supplying_facility_stock_on_hand_column.sql
@@ -1,0 +1,37 @@
+-- Register the read-only supplyingFacilityStockOnHand requisition-template column.
+--
+-- The column is display-only; its value is computed at read time, so no
+-- requisition_line_items column is added here (mirrors idealStockAmount registration).
+-- It is disabled by default: the column is added to every existing template with isdisplayed=false.
+-- Enabling it for a given implementation (e.g. Gambia) is done via template configuration, not here.
+
+-- (a) Register the available column. supportsTag is left to its DEFAULT false. canChangeOrder=true /
+--     canBeChangedByUser=false mirror the read-only 'stockOnHand' column.
+INSERT INTO requisition.available_requisition_columns
+  (id, name, label, indicator,
+   mandatory, isDisplayRequired, canChangeOrder, canBeChangedByUser, columnType, definition)
+VALUES
+  ('1a079695-9f34-4339-850c-1fc0d9675314', 'supplyingFacilityStockOnHand',
+   'Supplying facility stock on hand', 'SF',
+   false, false, true, false, 'NUMERIC',
+   'Stock on hand at the supplying facility for this product, displayed during approval');
+
+-- (b) Register the (only) allowed source. The value stores the SourceType enum NAME.
+INSERT INTO requisition.available_requisition_column_sources (columnId, value)
+VALUES ('1a079695-9f34-4339-850c-1fc0d9675314', 'SUPPLYING_FACILITY_STOCK');
+
+-- (c) Add the column to every existing template, DISABLED by default (isdisplayed=false).
+--     source = 5 is the ordinal of SUPPLYING_FACILITY_STOCK (columns_maps.source is persisted by
+--     ordinal). key = name keeps the (requisitiontemplateid, key) primary key unique.
+INSERT INTO requisition.columns_maps
+  (requisitiontemplateid, requisitioncolumnid, definition, displayorder, indicator,
+   isdisplayed, label, name, requisitioncolumnoptionid, source, key, tag)
+SELECT
+  t.id, a.id, a.definition, c.count + 1, a.indicator,
+  false, a.label, a.name, NULL, 5, a.name, NULL
+FROM
+  requisition.requisition_templates AS t
+  INNER JOIN (SELECT requisitiontemplateid, count(*) FROM requisition.columns_maps
+              GROUP BY requisitiontemplateid) AS c ON c.requisitiontemplateid = t.id
+  INNER JOIN requisition.available_requisition_columns AS a
+             ON a.name = 'supplyingFacilityStockOnHand';

--- a/src/test/java/org/openlmis/requisition/domain/SourceTypeTest.java
+++ b/src/test/java/org/openlmis/requisition/domain/SourceTypeTest.java
@@ -29,4 +29,21 @@ public class SourceTypeTest {
     assertFalse(SourceType.USER_INPUT.isReferenceSource());
     assertFalse(SourceType.CALCULATED.isReferenceSource());
   }
+
+  @Test
+  public void shouldCheckIfSourceIsStockType() {
+    assertTrue(SourceType.STOCK_CARDS.isStockSource());
+    assertFalse(SourceType.USER_INPUT.isStockSource());
+    assertFalse(SourceType.CALCULATED.isStockSource());
+    assertFalse(SourceType.REFERENCE_DATA.isStockSource());
+    assertFalse(SourceType.PREVIOUS_REQUISITION.isStockSource());
+  }
+
+  @Test
+  public void supplyingFacilityStockShouldBeNeitherReferenceNorStockSource() {
+    // It is display-only and has no backing line-item property; treating it as a stock source would
+    // make the line-item stock invariants reflect on a non-existent property and fail.
+    assertFalse(SourceType.SUPPLYING_FACILITY_STOCK.isReferenceSource());
+    assertFalse(SourceType.SUPPLYING_FACILITY_STOCK.isStockSource());
+  }
 }

--- a/src/test/java/org/openlmis/requisition/domain/requisition/RequisitionInvariantsValidatorTest.java
+++ b/src/test/java/org/openlmis/requisition/domain/requisition/RequisitionInvariantsValidatorTest.java
@@ -17,6 +17,7 @@ package org.openlmis.requisition.domain.requisition;
 
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
+import static org.javers.common.collections.Sets.asSet;
 import static org.junit.Assert.assertThat;
 import static org.openlmis.requisition.domain.requisition.Requisition.EMERGENCY_FIELD;
 import static org.openlmis.requisition.domain.requisition.Requisition.FACILITY_ID;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.openlmis.requisition.domain.RequisitionTemplateDataBuilder;
+import org.openlmis.requisition.domain.SourceType;
 import org.openlmis.requisition.dto.OrderableDto;
 import org.openlmis.requisition.dto.VersionIdentityDto;
 import org.openlmis.requisition.testutils.OrderableDtoDataBuilder;
@@ -98,6 +100,25 @@ public class RequisitionInvariantsValidatorTest {
   @Test
   public void shouldValidate() {
     validator.validateCanUpdate(errors);
+    assertThat(errors.entrySet(), hasSize(0));
+  }
+
+  @Test
+  public void shouldNotTreatSupplyingFacilityStockColumnAsStockField() throws Exception {
+    // On a stock-based template the SUPPLYING_FACILITY_STOCK column must be ignored by the
+    // line-item stock invariants (it is not a stock source), i.e. it must not be reflected on -
+    // it has no line-item property. Otherwise validation would fail with a reflection error.
+    requisitionToUpdate.setTemplate(new RequisitionTemplateDataBuilder()
+        .withAllColumns()
+        .withColumn("supplyingFacilityStockOnHand", "SF", SourceType.SUPPLYING_FACILITY_STOCK,
+            asSet(SourceType.SUPPLYING_FACILITY_STOCK), false)
+        .withPopulateStockOnHandFromStockCards()
+        .build()
+    );
+    requisitionUpdater.setTemplate(requisitionToUpdate.getTemplate());
+
+    validator.validateCanUpdate(errors);
+
     assertThat(errors.entrySet(), hasSize(0));
   }
 

--- a/src/test/java/org/openlmis/requisition/service/SupplyingFacilityStockServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/SupplyingFacilityStockServiceTest.java
@@ -1,0 +1,206 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.domain.RequisitionTemplate;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.OrderableDto;
+import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.dto.RequisitionLineItemDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
+import org.openlmis.requisition.exception.AuthenticationMessageException;
+import org.openlmis.requisition.service.referencedata.SupplyingFacilityResolver;
+import org.openlmis.requisition.service.stockmanagement.SupplyingFacilitySohAggregator;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.OrderableDtoDataBuilder;
+import org.openlmis.requisition.utils.Message;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplyingFacilityStockServiceTest {
+
+  private static final String COLUMN = "supplyingFacilityStockOnHand";
+
+  @Mock
+  private PermissionService permissionService;
+
+  @Mock
+  private SupplyingFacilityResolver resolver;
+
+  @Mock
+  private SupplyingFacilitySohAggregator aggregator;
+
+  @InjectMocks
+  private SupplyingFacilityStockService service;
+
+  private final UUID programId = UUID.randomUUID();
+
+  private Requisition requisition;
+  private RequisitionTemplate template;
+  private RequisitionDto dto;
+  private RequisitionLineItemDto lineItem;
+  private OrderableDto orderable;
+  private FacilityDto facility;
+
+  @Before
+  public void setUp() {
+    template = mock(RequisitionTemplate.class);
+    requisition = mock(Requisition.class);
+    when(requisition.getTemplate()).thenReturn(template);
+    when(requisition.getProgramId()).thenReturn(programId);
+    when(requisition.isApprovable()).thenReturn(true);
+    when(template.isColumnInTemplateAndDisplayed(COLUMN)).thenReturn(true);
+    when(permissionService.canApproveRequisition(requisition))
+        .thenReturn(ValidationResult.success());
+
+    orderable = new OrderableDtoDataBuilder().buildAsDto();
+    lineItem = new RequisitionLineItemDto();
+    lineItem.setOrderable(orderable);
+    dto = new RequisitionDto();
+    dto.setRequisitionLineItems(singletonList(lineItem));
+
+    facility = new FacilityDtoDataBuilder().buildAsDto();
+  }
+
+  private void allowStockCardsView() {
+    when(resolver.resolve(requisition)).thenReturn(singletonList(facility));
+    when(permissionService.canViewStockCards(facility.getId(), programId))
+        .thenReturn(ValidationResult.success());
+  }
+
+  @Test
+  public void shouldDoNothingWhenRequisitionIsNotApprovable() {
+    when(requisition.isApprovable()).thenReturn(false);
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(resolver, aggregator);
+  }
+
+  @Test
+  public void shouldDoNothingWhenTemplateColumnIsNotEnabled() {
+    when(template.isColumnInTemplateAndDisplayed(COLUMN)).thenReturn(false);
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(resolver, aggregator);
+  }
+
+  @Test
+  public void shouldDoNothingWhenCallerCannotApprove() {
+    when(permissionService.canApproveRequisition(requisition))
+        .thenReturn(ValidationResult.noPermission("requisition.error.noApprove"));
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(resolver, aggregator);
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoSupplyingFacilityResolved() {
+    when(resolver.resolve(requisition)).thenReturn(emptyList());
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(aggregator);
+  }
+
+  @Test
+  public void shouldSetAccessDeniedWhenCallerLacksStockCardsView() {
+    when(resolver.resolve(requisition)).thenReturn(singletonList(facility));
+    when(permissionService.canViewStockCards(facility.getId(), programId))
+        .thenReturn(ValidationResult.noPermission("requisition.error.noStockCardsView"));
+
+    service.enrich(requisition, dto);
+
+    assertTrue(dto.getSupplyingFacilityAccessDenied());
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(lineItem.getSupplyingFacilityStockOnHand());
+    verifyNoInteractions(aggregator);
+  }
+
+  @Test
+  public void shouldDegradeGracefullyWhenStockCardsViewRightIsNotRegistered() {
+    when(resolver.resolve(requisition)).thenReturn(singletonList(facility));
+    when(permissionService.canViewStockCards(facility.getId(), programId))
+        .thenThrow(new AuthenticationMessageException(
+            new Message("requisition.error.rightNotFound")));
+
+    service.enrich(requisition, dto);
+
+    assertTrue(dto.getSupplyingFacilityAccessDenied());
+    assertNull(dto.getSupplyingFacilities());
+    verifyNoInteractions(aggregator);
+  }
+
+  @Test
+  public void shouldPopulateFacilitiesAndStockOnHandOnSuccess() {
+    allowStockCardsView();
+    when(aggregator.aggregate(eq(programId), anyList(), anySet()))
+        .thenReturn(Optional.of(singletonMap(orderable.getId(), 300)));
+
+    service.enrich(requisition, dto);
+
+    assertThat(dto.getSupplyingFacilities(), hasSize(1));
+    assertThat(dto.getSupplyingFacilities().get(0).getId(), is(facility.getId()));
+    assertFalse(dto.getSupplyingFacilityAccessDenied());
+    assertThat(lineItem.getSupplyingFacilityStockOnHand(), is(300));
+  }
+
+  @Test
+  public void shouldPopulateFacilitiesButLeaveStockOnHandNullWhenLookupFails() {
+    allowStockCardsView();
+    when(aggregator.aggregate(eq(programId), anyList(), anySet())).thenReturn(Optional.empty());
+
+    service.enrich(requisition, dto);
+
+    assertThat(dto.getSupplyingFacilities(), hasSize(1));
+    assertFalse(dto.getSupplyingFacilityAccessDenied());
+    assertNull(lineItem.getSupplyingFacilityStockOnHand());
+  }
+}

--- a/src/test/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolverTest.java
+++ b/src/test/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolverTest.java
@@ -1,0 +1,93 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.referencedata;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.SupplyLineDtoDataBuilder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplyingFacilityResolverTest {
+
+  @Mock
+  private SupplyLineReferenceDataService supplyLineReferenceDataService;
+
+  @InjectMocks
+  private SupplyingFacilityResolver resolver;
+
+  private final UUID programId = UUID.randomUUID();
+  private final UUID supervisoryNodeId = UUID.randomUUID();
+
+  private Requisition requisition;
+
+  @Before
+  public void setUp() {
+    requisition = mock(Requisition.class);
+    when(requisition.getProgramId()).thenReturn(programId);
+    when(requisition.getSupervisoryNodeId()).thenReturn(supervisoryNodeId);
+  }
+
+  @Test
+  public void shouldResolveDistinctSupplyingFacilities() {
+    FacilityDto facilityA = new FacilityDtoDataBuilder().buildAsDto();
+    FacilityDto facilityB = new FacilityDtoDataBuilder().buildAsDto();
+    when(supplyLineReferenceDataService.search(programId, supervisoryNodeId))
+        .thenReturn(Arrays.asList(
+            new SupplyLineDtoDataBuilder().withSupplyingFacility(facilityA).buildAsDto(),
+            new SupplyLineDtoDataBuilder().withSupplyingFacility(facilityA).buildAsDto(),
+            new SupplyLineDtoDataBuilder().withSupplyingFacility(facilityB).buildAsDto()));
+
+    List<FacilityDto> result = resolver.resolve(requisition);
+
+    assertThat(result, contains(facilityA, facilityB));
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenNoSupplyLines() {
+    when(supplyLineReferenceDataService.search(programId, supervisoryNodeId))
+        .thenReturn(Collections.emptyList());
+
+    assertThat(resolver.resolve(requisition), hasSize(0));
+  }
+
+  @Test
+  public void shouldReturnEmptyAndSkipSearchWhenNoSupervisoryNode() {
+    when(requisition.getSupervisoryNodeId()).thenReturn(null);
+
+    assertThat(resolver.resolve(requisition), hasSize(0));
+    verify(supplyLineReferenceDataService, never()).search(any(UUID.class), any(UUID.class));
+  }
+}

--- a/src/test/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregatorTest.java
+++ b/src/test/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregatorTest.java
@@ -1,0 +1,151 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.stockmanagement;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.stockmanagement.StockCardSummaryDto;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.StockCardSummaryDtoDataBuilder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplyingFacilitySohAggregatorTest {
+
+  @Mock
+  private StockCardSummariesStockManagementService stockCardSummariesService;
+
+  private SupplyingFacilitySohAggregator aggregator;
+
+  private final UUID programId = UUID.randomUUID();
+  private final UUID orderableX = UUID.randomUUID();
+  private final UUID orderableY = UUID.randomUUID();
+
+  @Before
+  public void setUp() {
+    aggregator = new SupplyingFacilitySohAggregator(stockCardSummariesService);
+  }
+
+  private FacilityDto facility() {
+    return new FacilityDtoDataBuilder().buildAsDto();
+  }
+
+  private StockCardSummaryDto card(UUID orderableId, Integer stockOnHand) {
+    StockCardSummaryDto dto = new StockCardSummaryDtoDataBuilder()
+        .withOrderableId(orderableId)
+        .buildAsDto();
+    dto.setStockOnHand(stockOnHand);
+    return dto;
+  }
+
+  @Test
+  public void shouldReturnEmptyMapWithoutCallingStockServiceWhenNoFacilities() {
+    Optional<Map<UUID, Integer>> result =
+        aggregator.aggregate(programId, emptyList(), singleton(orderableX));
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get().isEmpty(), is(true));
+    verifyNoInteractions(stockCardSummariesService);
+  }
+
+  @Test
+  public void shouldSumStockOnHandAcrossLotsWithinFacility() {
+    FacilityDto facility = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facility.getId()), anySet(), isNull()))
+        .thenReturn(asList(card(orderableX, 30), card(orderableX, 70)));
+
+    Map<UUID, Integer> soh =
+        aggregator.aggregate(programId, singletonList(facility), singleton(orderableX)).get();
+
+    assertThat(soh.get(orderableX), is(100));
+  }
+
+  @Test
+  public void shouldTakeMaxAcrossFacilities() {
+    FacilityDto facilityA = facility();
+    FacilityDto facilityB = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facilityA.getId()), anySet(), isNull()))
+        .thenReturn(singletonList(card(orderableX, 300)));
+    when(stockCardSummariesService.search(eq(programId), eq(facilityB.getId()), anySet(), isNull()))
+        .thenReturn(singletonList(card(orderableX, 250)));
+
+    Map<UUID, Integer> soh =
+        aggregator.aggregate(programId, asList(facilityA, facilityB), singleton(orderableX)).get();
+
+    assertThat(soh.get(orderableX), is(300));
+  }
+
+  @Test
+  public void shouldPreserveZeroAndOmitNullStockOnHand() {
+    FacilityDto facility = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facility.getId()), anySet(), isNull()))
+        .thenReturn(asList(card(orderableX, 0), card(orderableY, null)));
+
+    Set<UUID> orderableIds = new HashSet<>(asList(orderableX, orderableY));
+    Map<UUID, Integer> soh =
+        aggregator.aggregate(programId, singletonList(facility), orderableIds).get();
+
+    assertThat(soh.get(orderableX), is(0));
+    assertThat(soh.containsKey(orderableY), is(false));
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenAnyFacilityLookupFails() {
+    FacilityDto facilityA = facility();
+    FacilityDto facilityB = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facilityA.getId()), anySet(), isNull()))
+        .thenReturn(singletonList(card(orderableX, 100)));
+    when(stockCardSummariesService.search(eq(programId), eq(facilityB.getId()), anySet(), isNull()))
+        .thenThrow(new IllegalStateException("stock service down"));
+
+    Optional<Map<UUID, Integer>> result =
+        aggregator.aggregate(programId, asList(facilityA, facilityB), singleton(orderableX));
+
+    assertThat(result.isPresent(), is(false));
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenSingleFacilityLookupFails() {
+    FacilityDto facility = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facility.getId()), anySet(), isNull()))
+        .thenThrow(new IllegalStateException("stock service down"));
+
+    Optional<Map<UUID, Integer>> result =
+        aggregator.aggregate(programId, singletonList(facility), singleton(orderableX));
+
+    assertThat(result.isPresent(), is(false));
+  }
+}

--- a/src/test/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidatorTest.java
+++ b/src/test/java/org/openlmis/requisition/validate/RequisitionTemplateDtoValidatorTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import static org.openlmis.requisition.domain.RequisitionTemplateColumn.DEFINITION_KEY;
 import static org.openlmis.requisition.domain.SourceType.CALCULATED;
 import static org.openlmis.requisition.domain.SourceType.STOCK_CARDS;
+import static org.openlmis.requisition.domain.SourceType.SUPPLYING_FACILITY_STOCK;
 import static org.openlmis.requisition.domain.SourceType.USER_INPUT;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_COLUMN_SOURCE_INVALID;
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_DISPLAYED_WHEN_CALC_ORDER_QUANTITY_EXPLANATION_NOT_DISPLAYED;
@@ -590,6 +591,35 @@ public class RequisitionTemplateDtoValidatorTest {
     validator.validate(template, errors);
 
     template.findColumn(TOTAL_LOSSES_AND_ADJUSTMENTS).setIsDisplayed(true);
+
+    verify(errors, never()).rejectValue(anyString(), anyString());
+  }
+
+  @Test
+  public void shouldNotRejectSupplyingFacilityStockColumnOnStockBasedTemplate() {
+    // The SUPPLYING_FACILITY_STOCK column must validate on a stock-based template and must not be
+    // forced to STOCK_CARDS (it is not part of STOCK_BASED_COLUMNS). This mirrors
+    // getTemplatePopulatedByStock() with the new column added.
+    RequisitionTemplate template = baseTemplateBuilder()
+        .withColumn(TOTAL_RECEIVED_QUANTITY, "B", USER_INPUT, Sets.newHashSet(USER_INPUT))
+        .withColumn(TOTAL_LOSSES_AND_ADJUSTMENTS, "D", STOCK_CARDS, Sets.newHashSet(STOCK_CARDS))
+        .withColumn(TOTAL_STOCKOUT_DAYS, "X", STOCK_CARDS, Sets.newHashSet(STOCK_CARDS))
+        .withColumn("supplyingFacilityStockOnHand", "SF", SUPPLYING_FACILITY_STOCK,
+            Sets.newHashSet(SUPPLYING_FACILITY_STOCK), false)
+        .withPopulateStockOnHandFromStockCards()
+        .build();
+
+    RequisitionTemplateDto dto = buildDto(template);
+    STOCK_BASED_COLUMNS
+        .stream()
+        .filter(dto::isColumnInTemplate)
+        .forEach(c -> {
+          dto.findColumn(c).setSource(STOCK_CARDS);
+          dto.findColumn(c).getColumnDefinition().getSources().add(STOCK_CARDS);
+        });
+    mockResponses(dto);
+
+    validator.validate(dto, errors);
 
     verify(errors, never()).rejectValue(anyString(), anyString());
   }

--- a/src/test/java/org/openlmis/requisition/web/BatchRequisitionControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/BatchRequisitionControllerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -31,6 +32,7 @@ import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 
 import org.junit.Before;
@@ -38,7 +40,13 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.openlmis.requisition.domain.RequisitionTemplate;
+import org.openlmis.requisition.domain.RequisitionTemplateColumn;
+import org.openlmis.requisition.domain.RequisitionTemplateColumnDataBuilder;
+import org.openlmis.requisition.domain.SourceType;
 import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.domain.requisition.RequisitionLineItem;
+import org.openlmis.requisition.domain.requisition.RequisitionLineItemDataBuilder;
 import org.openlmis.requisition.domain.requisition.RequisitionStatus;
 import org.openlmis.requisition.dto.ReleasableRequisitionBatchDto;
 import org.openlmis.requisition.dto.UserDto;
@@ -213,5 +221,30 @@ public class BatchRequisitionControllerTest {
     verify(periodReferenceDataService).search(anySet());
     verify(facilityTypeApprovedService).findByIdentities(anySet());
     verifyNoInteractions(stockEventBuilder, stockEventStockManagementService);
+  }
+
+  @Test
+  public void shouldNotFailNullingCalculatedFieldsForHiddenSupplyingFacilityStockColumn() {
+    // The supplyingFacilityStockOnHand column is read-only and has no line-item property, so a
+    // template carrying it hidden must not make the calculated-field nulling reflect on a missing
+    // setter (which would throw). See getColumnNameConditions in BatchRequisitionController.
+    RequisitionTemplateColumn hiddenColumn = new RequisitionTemplateColumnDataBuilder()
+        .withName("supplyingFacilityStockOnHand")
+        .withSource(SourceType.SUPPLYING_FACILITY_STOCK)
+        .withNotDisplayed()
+        .build();
+    Map<String, RequisitionTemplateColumn> columns =
+        Collections.singletonMap("supplyingFacilityStockOnHand", hiddenColumn);
+
+    RequisitionTemplate template = mock(RequisitionTemplate.class);
+    when(template.viewColumns()).thenReturn(columns);
+
+    RequisitionLineItem lineItem = new RequisitionLineItemDataBuilder().build();
+    when(requisition.getTemplate()).thenReturn(template);
+    when(requisition.getRequisitionLineItems()).thenReturn(Collections.singletonList(lineItem));
+
+    // Fails (throws IllegalArgumentException) without the exception-list entry.
+    ReflectionTestUtils.invokeMethod(
+        batchRequisitionController, "setNullForCalculatedFields", requisition);
   }
 }

--- a/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
@@ -118,6 +118,7 @@ import org.openlmis.requisition.service.RequisitionService;
 import org.openlmis.requisition.service.RequisitionStatusNotifier;
 import org.openlmis.requisition.service.RequisitionStatusProcessor;
 import org.openlmis.requisition.service.RequisitionTemplateService;
+import org.openlmis.requisition.service.SupplyingFacilityStockService;
 import org.openlmis.requisition.service.referencedata.ApproveProductsAggregator;
 import org.openlmis.requisition.service.referencedata.ApprovedProductReferenceDataService;
 import org.openlmis.requisition.service.referencedata.FacilityReferenceDataService;
@@ -160,6 +161,9 @@ public class RequisitionControllerTest {
 
   @Mock
   private RequisitionService requisitionService;
+
+  @Mock
+  private SupplyingFacilityStockService supplyingFacilityStockService;
 
   @Mock
   private PeriodService periodService;


### PR DESCRIPTION
## Summary

Registers a new read-only requisition-template column, supplyingFacilityStockOnHand (indicator SF, type NUMERIC), so it can be configured per template, and thus per facility type. It is disabled by default.

This is the backend groundwork for showing approving officers the supplying facility's stock on hand during approval. The value computation and API are a follow-up, and the approval-grid UI is a separate frontend task. It covers section 2 of the HLD: [Supplying Facility Stock Visibility](https://openlmis.atlassian.net/wiki/spaces/OP/pages/3906732077/Supplying+Facility+Stock+Visibility).

## Changes

- SourceType: add SUPPLYING_FACILITY_STOCK, appended last because columns_maps.source is persisted by enum ordinal. It is deliberately neither a reference nor a stock source (see Notes).
- Flyway migration: register the available column and its source, and add it to every existing template with isdisplayed = false. No requisition_line_items column is created; the value is computed at read time in the follow-up.
- BatchRequisitionController: add the column to the set of columns that have no settable RequisitionLineItem property, so batch approval does not reflectively null a non-existent field (which would return 500). The inlined exception list is now a named constant.
- Unit and integration tests, and a CHANGELOG entry.

## Notes and decisions

- Neither a stock nor a reference source. This is an intentional deviation from the HLD wording. Marking the source as stock would make RequisitionInvariantsValidator reflect on a non-existent RequisitionLineItem getter and return 500 on update or approve for stock-based templates, because the column is display-only with no backing line-item property. The "behaves like a stock column in the template editor" behaviour is a frontend concern. The reviewer confirmed the deviation is acceptable as long as the functional assumptions hold.
- Reports are unaffected. The print report renders a template column only when the .jrxml band has a matching keyed element. None is added for this column, so it never appears in a report even when a template enables it.
- No implementation-specific enablement in core. Turning the column on for existing templates is left to template configuration or downstream, so this core migration does not enable it on any single deployment.

## Testing

- SourceTypeTest: the new source is neither a reference nor a stock source.
- BatchRequisitionControllerTest: a template carrying the hidden column does not break batch approval.
- RequisitionTemplateDtoValidatorTest: the column validates on a stock-based template and is not forced to STOCK_CARDS.
- RequisitionInvariantsValidatorTest: the column is not treated as a line-item stock field.
- AvailableRequisitionColumnRepositoryIntegrationTest: the column is registered with the expected attributes and source.
- The full unit suite passes; checkstyle and PMD are clean.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/132)
<!-- Reviewable:end -->
