### PR TITLE
OPSD-99: Return supplying-facility stock on hand in GET /api/requisitions/{id}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
 Improvements:
+* [OPSD-99](https://openlmis.atlassian.net/browse/OPSD-99): Return supplying-facility stock on hand and supplying-facility metadata in GET /api/requisitions/{id} for approval-eligible requisitions, gated by the supplyingFacilityStockOnHand template column and STOCK_CARDS_VIEW at the supplying facility (display-only; the approve endpoint is unchanged).
 * [OPSD-98](https://openlmis.atlassian.net/browse/OPSD-98): Registered the read-only supplyingFacilityStockOnHand requisition-template column (disabled by default, kept out of generated requisition reports).
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Migrated the SonarCloud analysis to Java 21 by running it through the SonarQube scan action instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).

--- a/src/main/java/org/openlmis/requisition/dto/BaseRequisitionDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/BaseRequisitionDto.java
@@ -101,6 +101,17 @@ public abstract class BaseRequisitionDto
   @Setter
   private Map<String, Object> extraData;
 
+  // Supplying-facility stock visibility (populated only for approval-eligible requisitions when the
+  // template column is enabled and the caller is authorised; see SupplyingFacilityStockService).
+  // Distinct from the single supplyingFacility UUID above (convert-to-order depot).
+  @Getter
+  @Setter
+  private List<SupplyingFacilityDto> supplyingFacilities;
+
+  @Getter
+  @Setter
+  private Boolean supplyingFacilityAccessDenied;
+
   @Override
   public List<RequisitionLineItem.Importer> getRequisitionLineItems() {
     return new ArrayList<>(

--- a/src/main/java/org/openlmis/requisition/dto/BaseRequisitionLineItemDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/BaseRequisitionLineItemDto.java
@@ -76,6 +76,10 @@ public abstract class BaseRequisitionLineItemDto extends BaseDto
   private Integer convertedQuantityToIssue;
   private Integer dosesPerPatient;
 
+  // Read-only supplying-facility stock on hand for this orderable, computed at read time during
+  // approval (see SupplyingFacilityStockService). Not persisted; not on the line-item Importer.
+  private Integer supplyingFacilityStockOnHand;
+
   @JsonProperty
   private List<StockAdjustmentDto> stockAdjustments = new ArrayList<>();
 

--- a/src/main/java/org/openlmis/requisition/dto/SupplyingFacilityDto.java
+++ b/src/main/java/org/openlmis/requisition/dto/SupplyingFacilityDto.java
@@ -1,0 +1,41 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.dto;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Lean representation of a supplying facility ({@code id}, {@code code}, {@code name}) exposed on
+ * the requisition read payload during approval. Distinct from the requisition-level
+ * {@code supplyingFacility} UUID, which denotes the convert-to-order depot.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+public class SupplyingFacilityDto {
+  private UUID id;
+  private String code;
+  private String name;
+}

--- a/src/main/java/org/openlmis/requisition/service/PermissionService.java
+++ b/src/main/java/org/openlmis/requisition/service/PermissionService.java
@@ -54,6 +54,8 @@ public class PermissionService {
 
   public static final String ORDERS_EDIT = "ORDERS_EDIT";
 
+  public static final String STOCK_CARDS_VIEW = "STOCK_CARDS_VIEW";
+
   @Autowired
   private RightAssignmentPermissionValidator rightAssignmentPermissionValidator;
 
@@ -279,6 +281,19 @@ public class PermissionService {
     return ValidationResult
         .noPermission(ERROR_NO_FOLLOWING_PERMISSION_FOR_REQUISITION_UPDATE,
             status.toString(), rightName);
+  }
+
+  /**
+   * Checks whether the current user may view stock cards at the given facility. Used by the
+   * supplying-facility stock-on-hand feature to gate display of the value, not the cross-service
+   * stock fetch itself (which uses the service account). Evaluated under the ambient user token.
+   *
+   * @param facilityId the resolved supplying facility to evaluate the right at
+   * @param programId  the requisition program
+   * @return success when the user holds STOCK_CARDS_VIEW at the facility, no-permission otherwise
+   */
+  public ValidationResult canViewStockCards(UUID facilityId, UUID programId) {
+    return checkRight(STOCK_CARDS_VIEW, facilityId, programId);
   }
 
   private ValidationResult checkRight(String rightName) {

--- a/src/main/java/org/openlmis/requisition/service/SupplyingFacilityStockService.java
+++ b/src/main/java/org/openlmis/requisition/service/SupplyingFacilityStockService.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.openlmis.requisition.domain.requisition.Requisition;
 import org.openlmis.requisition.domain.requisition.RequisitionLineItem;
 import org.openlmis.requisition.dto.BaseRequisitionDto;
@@ -33,7 +34,6 @@ import org.openlmis.requisition.service.referencedata.SupplyingFacilityResolver;
 import org.openlmis.requisition.service.stockmanagement.SupplyingFacilitySohAggregator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 /**
@@ -43,6 +43,7 @@ import org.springframework.stereotype.Service;
  * the DTO is left untouched. Display-only: the approve endpoint is never involved.
  */
 @Service
+@RequiredArgsConstructor
 public class SupplyingFacilityStockService {
 
   static final String COLUMN = "supplyingFacilityStockOnHand";
@@ -53,21 +54,6 @@ public class SupplyingFacilityStockService {
   private final PermissionService permissionService;
   private final SupplyingFacilityResolver resolver;
   private final SupplyingFacilitySohAggregator aggregator;
-
-  /**
-   * Creates the service.
-   *
-   * @param permissionService gate for approval and stock-card-view rights
-   * @param resolver          resolves the supplying facilities from SupplyLine
-   * @param aggregator        fetches and aggregates supplying-facility stock on hand
-   */
-  @Autowired
-  public SupplyingFacilityStockService(PermissionService permissionService,
-      SupplyingFacilityResolver resolver, SupplyingFacilitySohAggregator aggregator) {
-    this.permissionService = permissionService;
-    this.resolver = resolver;
-    this.aggregator = aggregator;
-  }
 
   /**
    * Adds supplying-facility metadata and per-line stock on hand to the DTO when the requisition is

--- a/src/main/java/org/openlmis/requisition/service/SupplyingFacilityStockService.java
+++ b/src/main/java/org/openlmis/requisition/service/SupplyingFacilityStockService.java
@@ -1,0 +1,143 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.domain.requisition.RequisitionLineItem;
+import org.openlmis.requisition.dto.BaseRequisitionDto;
+import org.openlmis.requisition.dto.BaseRequisitionLineItemDto;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.SupplyingFacilityDto;
+import org.openlmis.requisition.dto.VersionIdentityDto;
+import org.openlmis.requisition.exception.AuthenticationMessageException;
+import org.openlmis.requisition.service.referencedata.SupplyingFacilityResolver;
+import org.openlmis.requisition.service.stockmanagement.SupplyingFacilitySohAggregator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * Populates supplying-facility stock-on-hand fields on a requisition read DTO during approval. The
+ * whole flow is gated (approval-eligible status, template column enabled, caller can approve, and
+ * the caller holds STOCK_CARDS_VIEW at the resolved supplying facility); unless every gate passes
+ * the DTO is left untouched. Display-only: the approve endpoint is never involved.
+ */
+@Service
+public class SupplyingFacilityStockService {
+
+  static final String COLUMN = "supplyingFacilityStockOnHand";
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SupplyingFacilityStockService.class);
+
+  private final PermissionService permissionService;
+  private final SupplyingFacilityResolver resolver;
+  private final SupplyingFacilitySohAggregator aggregator;
+
+  /**
+   * Creates the service.
+   *
+   * @param permissionService gate for approval and stock-card-view rights
+   * @param resolver          resolves the supplying facilities from SupplyLine
+   * @param aggregator        fetches and aggregates supplying-facility stock on hand
+   */
+  @Autowired
+  public SupplyingFacilityStockService(PermissionService permissionService,
+      SupplyingFacilityResolver resolver, SupplyingFacilitySohAggregator aggregator) {
+    this.permissionService = permissionService;
+    this.resolver = resolver;
+    this.aggregator = aggregator;
+  }
+
+  /**
+   * Adds supplying-facility metadata and per-line stock on hand to the DTO when the requisition is
+   * approval-eligible, the template column is enabled and the caller is authorised. A no-op
+   * otherwise, so payloads stay unchanged for every non-approval read.
+   *
+   * @param requisition the requisition being read
+   * @param dto         the response DTO to enrich in place
+   */
+  public void enrich(Requisition requisition, BaseRequisitionDto dto) {
+    if (!requisition.isApprovable()
+        || !requisition.getTemplate().isColumnInTemplateAndDisplayed(COLUMN)) {
+      return;
+    }
+    // Receiving-side roles must not see supplying-facility stock and get no notification.
+    if (!permissionService.canApproveRequisition(requisition).isSuccess()) {
+      return;
+    }
+    List<FacilityDto> facilities = resolver.resolve(requisition);
+    if (facilities.isEmpty()) {
+      return;
+    }
+    if (!hasStockCardsView(facilities, requisition.getProgramId())) {
+      dto.setSupplyingFacilityAccessDenied(true);
+      return;
+    }
+
+    dto.setSupplyingFacilities(toSupplyingFacilityDtos(facilities));
+    dto.setSupplyingFacilityAccessDenied(false);
+
+    List<RequisitionLineItem.Importer> lineItems = dto.getRequisitionLineItems();
+    aggregator.aggregate(requisition.getProgramId(), facilities, orderableIds(lineItems))
+        .ifPresent(byOrderable -> populateLineItemStockOnHand(lineItems, byOrderable));
+  }
+
+  private boolean hasStockCardsView(List<FacilityDto> facilities, UUID programId) {
+    try {
+      return facilities.stream().allMatch(facility ->
+          permissionService.canViewStockCards(facility.getId(), programId).isSuccess());
+    } catch (AuthenticationMessageException ex) {
+      // STOCK_CARDS_VIEW is not registered in this deployment; degrade gracefully rather than 500.
+      LOGGER.warn("Could not evaluate STOCK_CARDS_VIEW; supplying-facility stock not shown", ex);
+      return false;
+    }
+  }
+
+  private List<SupplyingFacilityDto> toSupplyingFacilityDtos(List<FacilityDto> facilities) {
+    return facilities.stream()
+        .map(facility ->
+            new SupplyingFacilityDto(facility.getId(), facility.getCode(), facility.getName()))
+        .collect(Collectors.toList());
+  }
+
+  private Set<UUID> orderableIds(List<RequisitionLineItem.Importer> lineItems) {
+    return lineItems.stream()
+        .map(RequisitionLineItem.Importer::getOrderableIdentity)
+        .filter(Objects::nonNull)
+        .map(VersionIdentityDto::getId)
+        .collect(Collectors.toSet());
+  }
+
+  private void populateLineItemStockOnHand(List<RequisitionLineItem.Importer> lineItems,
+      Map<UUID, Integer> byOrderable) {
+    for (RequisitionLineItem.Importer importer : lineItems) {
+      VersionIdentityDto orderable = importer.getOrderableIdentity();
+      if (orderable != null) {
+        // The only Importer implementor is BaseRequisitionLineItemDto, which owns the setter.
+        BaseRequisitionLineItemDto line = (BaseRequisitionLineItemDto) importer;
+        line.setSupplyingFacilityStockOnHand(byOrderable.get(orderable.getId()));
+      }
+    }
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolver.java
+++ b/src/main/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolver.java
@@ -1,0 +1,67 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.referencedata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.SupplyLineDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves the distinct supplying facilities for a requisition using the existing SupplyLine
+ * configuration for its (program, current supervisory node). Internal only; not exposed over HTTP.
+ */
+@Component
+public class SupplyingFacilityResolver {
+
+  private final SupplyLineReferenceDataService supplyLineReferenceDataService;
+
+  @Autowired
+  public SupplyingFacilityResolver(
+      SupplyLineReferenceDataService supplyLineReferenceDataService) {
+    this.supplyLineReferenceDataService = supplyLineReferenceDataService;
+  }
+
+  /**
+   * Resolves the distinct supplying facilities for the requisition. Returns an empty list when the
+   * requisition has no supervisory node or no matching SupplyLine (i.e. "not configured").
+   *
+   * @param requisition the requisition being read
+   * @return distinct supplying facilities, in SupplyLine order
+   */
+  public List<FacilityDto> resolve(Requisition requisition) {
+    if (requisition.getSupervisoryNodeId() == null) {
+      return Collections.emptyList();
+    }
+
+    Map<UUID, FacilityDto> distinctById = new LinkedHashMap<>();
+    for (SupplyLineDto supplyLine : supplyLineReferenceDataService
+        .search(requisition.getProgramId(), requisition.getSupervisoryNodeId())) {
+      FacilityDto facility = supplyLine.getSupplyingFacility();
+      if (facility != null) {
+        distinctById.putIfAbsent(facility.getId(), facility);
+      }
+    }
+    return new ArrayList<>(distinctById.values());
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolver.java
+++ b/src/main/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolver.java
@@ -21,10 +21,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.openlmis.requisition.domain.requisition.Requisition;
 import org.openlmis.requisition.dto.FacilityDto;
 import org.openlmis.requisition.dto.SupplyLineDto;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -32,15 +32,10 @@ import org.springframework.stereotype.Component;
  * configuration for its (program, current supervisory node). Internal only; not exposed over HTTP.
  */
 @Component
+@RequiredArgsConstructor
 public class SupplyingFacilityResolver {
 
   private final SupplyLineReferenceDataService supplyLineReferenceDataService;
-
-  @Autowired
-  public SupplyingFacilityResolver(
-      SupplyLineReferenceDataService supplyLineReferenceDataService) {
-    this.supplyLineReferenceDataService = supplyLineReferenceDataService;
-  }
 
   /**
    * Resolves the distinct supplying facilities for the requisition. Returns an empty list when the

--- a/src/main/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregator.java
+++ b/src/main/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregator.java
@@ -1,0 +1,89 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.stockmanagement;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.stockmanagement.StockCardSummaryDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Fetches supplying-facility stock on hand and aggregates it per orderable: sum across each
+ * facility's lots, then maximum across facilities (the largest single depot that could supply the
+ * line). The cross-service call uses the service account, so no facility-scoped token is needed.
+ * Any single lookup failure yields no values at all, so approvers never see an under-counted total.
+ */
+@Component
+public class SupplyingFacilitySohAggregator {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(SupplyingFacilitySohAggregator.class);
+
+  private final StockCardSummariesStockManagementService stockCardSummariesService;
+
+  @Autowired
+  public SupplyingFacilitySohAggregator(
+      StockCardSummariesStockManagementService stockCardSummariesService) {
+    this.stockCardSummariesService = stockCardSummariesService;
+  }
+
+  /**
+   * Aggregates supplying-facility SOH per orderable.
+   *
+   * @return {@code Optional.empty()} when any per-facility lookup failed (all SOH treated as null);
+   *         otherwise a map of orderable id to the max-across-facilities of the per-facility lot
+   *         sums. An orderable absent from the map has no stock card (line SOH is null), which is
+   *         distinct from a mapped value of {@code 0} (a card exists but is empty).
+   */
+  public Optional<Map<UUID, Integer>> aggregate(UUID programId, List<FacilityDto> facilities,
+      Set<UUID> orderableIds) {
+    if (facilities.isEmpty() || orderableIds.isEmpty()) {
+      return Optional.of(Collections.emptyMap());
+    }
+
+    Map<UUID, Integer> byOrderable = new HashMap<>();
+    for (FacilityDto facility : facilities) {
+      try {
+        perFacilitySoh(programId, facility.getId(), orderableIds)
+            .forEach((orderableId, soh) -> byOrderable.merge(orderableId, soh, Integer::max));
+      } catch (RuntimeException ex) {
+        LOGGER.warn("Supplying-facility stock-on-hand lookup failed for facility {}",
+            facility.getId(), ex);
+        return Optional.empty();
+      }
+    }
+    return Optional.of(byOrderable);
+  }
+
+  private Map<UUID, Integer> perFacilitySoh(UUID programId, UUID facilityId,
+      Set<UUID> orderableIds) {
+    return stockCardSummariesService.search(programId, facilityId, orderableIds, null)
+        .stream()
+        .filter(card -> card.getOrderable() != null && card.getStockOnHand() != null)
+        .collect(Collectors.groupingBy(card -> card.getOrderable().getId(),
+            Collectors.summingInt(StockCardSummaryDto::getStockOnHand)));
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregator.java
+++ b/src/main/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregator.java
@@ -23,11 +23,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.openlmis.requisition.dto.FacilityDto;
 import org.openlmis.requisition.dto.stockmanagement.StockCardSummaryDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -37,18 +37,13 @@ import org.springframework.stereotype.Component;
  * Any single lookup failure yields no values at all, so approvers never see an under-counted total.
  */
 @Component
+@RequiredArgsConstructor
 public class SupplyingFacilitySohAggregator {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SupplyingFacilitySohAggregator.class);
 
   private final StockCardSummariesStockManagementService stockCardSummariesService;
-
-  @Autowired
-  public SupplyingFacilitySohAggregator(
-      StockCardSummariesStockManagementService stockCardSummariesService) {
-    this.stockCardSummariesService = stockCardSummariesService;
-  }
 
   /**
    * Aggregates supplying-facility SOH per orderable.

--- a/src/main/java/org/openlmis/requisition/web/RequisitionController.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionController.java
@@ -51,6 +51,7 @@ import org.openlmis.requisition.i18n.MessageKeys;
 import org.openlmis.requisition.repository.custom.DefaultRequisitionSearchParams;
 import org.openlmis.requisition.repository.custom.RequisitionSearchParams;
 import org.openlmis.requisition.service.RequisitionStatusNotifier;
+import org.openlmis.requisition.service.SupplyingFacilityStockService;
 import org.openlmis.requisition.service.referencedata.SupervisoryNodeReferenceDataService;
 import org.openlmis.requisition.utils.Message;
 import org.openlmis.requisition.utils.Pagination;
@@ -85,6 +86,9 @@ public class RequisitionController extends BaseRequisitionController {
 
   @Autowired
   private RequisitionStatusNotifier requisitionStatusNotifier;
+
+  @Autowired
+  private SupplyingFacilityStockService supplyingFacilityStockService;
 
   @Autowired
   private SupervisoryNodeReferenceDataService supervisoryNodeService;
@@ -312,6 +316,9 @@ public class RequisitionController extends BaseRequisitionController {
         findProgram(requisition.getProgramId(), profiler),
         null
     );
+
+    profiler.start("POPULATE_SUPPLYING_FACILITY_SOH");
+    supplyingFacilityStockService.enrich(requisition, requisitionDto);
 
     stopProfiler(profiler, requisitionDto);
 

--- a/src/test/java/org/openlmis/requisition/service/SupplyingFacilityStockServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/SupplyingFacilityStockServiceTest.java
@@ -1,0 +1,206 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.domain.RequisitionTemplate;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.OrderableDto;
+import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.dto.RequisitionLineItemDto;
+import org.openlmis.requisition.errorhandling.ValidationResult;
+import org.openlmis.requisition.exception.AuthenticationMessageException;
+import org.openlmis.requisition.service.referencedata.SupplyingFacilityResolver;
+import org.openlmis.requisition.service.stockmanagement.SupplyingFacilitySohAggregator;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.OrderableDtoDataBuilder;
+import org.openlmis.requisition.utils.Message;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplyingFacilityStockServiceTest {
+
+  private static final String COLUMN = "supplyingFacilityStockOnHand";
+
+  @Mock
+  private PermissionService permissionService;
+
+  @Mock
+  private SupplyingFacilityResolver resolver;
+
+  @Mock
+  private SupplyingFacilitySohAggregator aggregator;
+
+  @InjectMocks
+  private SupplyingFacilityStockService service;
+
+  private final UUID programId = UUID.randomUUID();
+
+  private Requisition requisition;
+  private RequisitionTemplate template;
+  private RequisitionDto dto;
+  private RequisitionLineItemDto lineItem;
+  private OrderableDto orderable;
+  private FacilityDto facility;
+
+  @Before
+  public void setUp() {
+    template = mock(RequisitionTemplate.class);
+    requisition = mock(Requisition.class);
+    when(requisition.getTemplate()).thenReturn(template);
+    when(requisition.getProgramId()).thenReturn(programId);
+    when(requisition.isApprovable()).thenReturn(true);
+    when(template.isColumnInTemplateAndDisplayed(COLUMN)).thenReturn(true);
+    when(permissionService.canApproveRequisition(requisition))
+        .thenReturn(ValidationResult.success());
+
+    orderable = new OrderableDtoDataBuilder().buildAsDto();
+    lineItem = new RequisitionLineItemDto();
+    lineItem.setOrderable(orderable);
+    dto = new RequisitionDto();
+    dto.setRequisitionLineItems(singletonList(lineItem));
+
+    facility = new FacilityDtoDataBuilder().buildAsDto();
+  }
+
+  private void allowStockCardsView() {
+    when(resolver.resolve(requisition)).thenReturn(singletonList(facility));
+    when(permissionService.canViewStockCards(facility.getId(), programId))
+        .thenReturn(ValidationResult.success());
+  }
+
+  @Test
+  public void shouldDoNothingWhenRequisitionIsNotApprovable() {
+    when(requisition.isApprovable()).thenReturn(false);
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(resolver, aggregator);
+  }
+
+  @Test
+  public void shouldDoNothingWhenTemplateColumnIsNotEnabled() {
+    when(template.isColumnInTemplateAndDisplayed(COLUMN)).thenReturn(false);
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(resolver, aggregator);
+  }
+
+  @Test
+  public void shouldDoNothingWhenCallerCannotApprove() {
+    when(permissionService.canApproveRequisition(requisition))
+        .thenReturn(ValidationResult.noPermission("requisition.error.noApprove"));
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(resolver, aggregator);
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoSupplyingFacilityResolved() {
+    when(resolver.resolve(requisition)).thenReturn(emptyList());
+
+    service.enrich(requisition, dto);
+
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(dto.getSupplyingFacilityAccessDenied());
+    verifyNoInteractions(aggregator);
+  }
+
+  @Test
+  public void shouldSetAccessDeniedWhenCallerLacksStockCardsView() {
+    when(resolver.resolve(requisition)).thenReturn(singletonList(facility));
+    when(permissionService.canViewStockCards(facility.getId(), programId))
+        .thenReturn(ValidationResult.noPermission("requisition.error.noStockCardsView"));
+
+    service.enrich(requisition, dto);
+
+    assertTrue(dto.getSupplyingFacilityAccessDenied());
+    assertNull(dto.getSupplyingFacilities());
+    assertNull(lineItem.getSupplyingFacilityStockOnHand());
+    verifyNoInteractions(aggregator);
+  }
+
+  @Test
+  public void shouldDegradeGracefullyWhenStockCardsViewRightIsNotRegistered() {
+    when(resolver.resolve(requisition)).thenReturn(singletonList(facility));
+    when(permissionService.canViewStockCards(facility.getId(), programId))
+        .thenThrow(new AuthenticationMessageException(
+            new Message("requisition.error.rightNotFound")));
+
+    service.enrich(requisition, dto);
+
+    assertTrue(dto.getSupplyingFacilityAccessDenied());
+    assertNull(dto.getSupplyingFacilities());
+    verifyNoInteractions(aggregator);
+  }
+
+  @Test
+  public void shouldPopulateFacilitiesAndStockOnHandOnSuccess() {
+    allowStockCardsView();
+    when(aggregator.aggregate(eq(programId), anyList(), anySet()))
+        .thenReturn(Optional.of(singletonMap(orderable.getId(), 300)));
+
+    service.enrich(requisition, dto);
+
+    assertThat(dto.getSupplyingFacilities(), hasSize(1));
+    assertThat(dto.getSupplyingFacilities().get(0).getId(), is(facility.getId()));
+    assertFalse(dto.getSupplyingFacilityAccessDenied());
+    assertThat(lineItem.getSupplyingFacilityStockOnHand(), is(300));
+  }
+
+  @Test
+  public void shouldPopulateFacilitiesButLeaveStockOnHandNullWhenLookupFails() {
+    allowStockCardsView();
+    when(aggregator.aggregate(eq(programId), anyList(), anySet())).thenReturn(Optional.empty());
+
+    service.enrich(requisition, dto);
+
+    assertThat(dto.getSupplyingFacilities(), hasSize(1));
+    assertFalse(dto.getSupplyingFacilityAccessDenied());
+    assertNull(lineItem.getSupplyingFacilityStockOnHand());
+  }
+}

--- a/src/test/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolverTest.java
+++ b/src/test/java/org/openlmis/requisition/service/referencedata/SupplyingFacilityResolverTest.java
@@ -1,0 +1,93 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.referencedata;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.SupplyLineDtoDataBuilder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplyingFacilityResolverTest {
+
+  @Mock
+  private SupplyLineReferenceDataService supplyLineReferenceDataService;
+
+  @InjectMocks
+  private SupplyingFacilityResolver resolver;
+
+  private final UUID programId = UUID.randomUUID();
+  private final UUID supervisoryNodeId = UUID.randomUUID();
+
+  private Requisition requisition;
+
+  @Before
+  public void setUp() {
+    requisition = mock(Requisition.class);
+    when(requisition.getProgramId()).thenReturn(programId);
+    when(requisition.getSupervisoryNodeId()).thenReturn(supervisoryNodeId);
+  }
+
+  @Test
+  public void shouldResolveDistinctSupplyingFacilities() {
+    FacilityDto facilityA = new FacilityDtoDataBuilder().buildAsDto();
+    FacilityDto facilityB = new FacilityDtoDataBuilder().buildAsDto();
+    when(supplyLineReferenceDataService.search(programId, supervisoryNodeId))
+        .thenReturn(Arrays.asList(
+            new SupplyLineDtoDataBuilder().withSupplyingFacility(facilityA).buildAsDto(),
+            new SupplyLineDtoDataBuilder().withSupplyingFacility(facilityA).buildAsDto(),
+            new SupplyLineDtoDataBuilder().withSupplyingFacility(facilityB).buildAsDto()));
+
+    List<FacilityDto> result = resolver.resolve(requisition);
+
+    assertThat(result, contains(facilityA, facilityB));
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenNoSupplyLines() {
+    when(supplyLineReferenceDataService.search(programId, supervisoryNodeId))
+        .thenReturn(Collections.emptyList());
+
+    assertThat(resolver.resolve(requisition), hasSize(0));
+  }
+
+  @Test
+  public void shouldReturnEmptyAndSkipSearchWhenNoSupervisoryNode() {
+    when(requisition.getSupervisoryNodeId()).thenReturn(null);
+
+    assertThat(resolver.resolve(requisition), hasSize(0));
+    verify(supplyLineReferenceDataService, never()).search(any(UUID.class), any(UUID.class));
+  }
+}

--- a/src/test/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregatorTest.java
+++ b/src/test/java/org/openlmis/requisition/service/stockmanagement/SupplyingFacilitySohAggregatorTest.java
@@ -1,0 +1,151 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.stockmanagement;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openlmis.requisition.dto.FacilityDto;
+import org.openlmis.requisition.dto.stockmanagement.StockCardSummaryDto;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.StockCardSummaryDtoDataBuilder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SupplyingFacilitySohAggregatorTest {
+
+  @Mock
+  private StockCardSummariesStockManagementService stockCardSummariesService;
+
+  private SupplyingFacilitySohAggregator aggregator;
+
+  private final UUID programId = UUID.randomUUID();
+  private final UUID orderableX = UUID.randomUUID();
+  private final UUID orderableY = UUID.randomUUID();
+
+  @Before
+  public void setUp() {
+    aggregator = new SupplyingFacilitySohAggregator(stockCardSummariesService);
+  }
+
+  private FacilityDto facility() {
+    return new FacilityDtoDataBuilder().buildAsDto();
+  }
+
+  private StockCardSummaryDto card(UUID orderableId, Integer stockOnHand) {
+    StockCardSummaryDto dto = new StockCardSummaryDtoDataBuilder()
+        .withOrderableId(orderableId)
+        .buildAsDto();
+    dto.setStockOnHand(stockOnHand);
+    return dto;
+  }
+
+  @Test
+  public void shouldReturnEmptyMapWithoutCallingStockServiceWhenNoFacilities() {
+    Optional<Map<UUID, Integer>> result =
+        aggregator.aggregate(programId, emptyList(), singleton(orderableX));
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get().isEmpty(), is(true));
+    verifyNoInteractions(stockCardSummariesService);
+  }
+
+  @Test
+  public void shouldSumStockOnHandAcrossLotsWithinFacility() {
+    FacilityDto facility = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facility.getId()), anySet(), isNull()))
+        .thenReturn(asList(card(orderableX, 30), card(orderableX, 70)));
+
+    Map<UUID, Integer> soh =
+        aggregator.aggregate(programId, singletonList(facility), singleton(orderableX)).get();
+
+    assertThat(soh.get(orderableX), is(100));
+  }
+
+  @Test
+  public void shouldTakeMaxAcrossFacilities() {
+    FacilityDto facilityA = facility();
+    FacilityDto facilityB = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facilityA.getId()), anySet(), isNull()))
+        .thenReturn(singletonList(card(orderableX, 300)));
+    when(stockCardSummariesService.search(eq(programId), eq(facilityB.getId()), anySet(), isNull()))
+        .thenReturn(singletonList(card(orderableX, 250)));
+
+    Map<UUID, Integer> soh =
+        aggregator.aggregate(programId, asList(facilityA, facilityB), singleton(orderableX)).get();
+
+    assertThat(soh.get(orderableX), is(300));
+  }
+
+  @Test
+  public void shouldPreserveZeroAndOmitNullStockOnHand() {
+    FacilityDto facility = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facility.getId()), anySet(), isNull()))
+        .thenReturn(asList(card(orderableX, 0), card(orderableY, null)));
+
+    Set<UUID> orderableIds = new HashSet<>(asList(orderableX, orderableY));
+    Map<UUID, Integer> soh =
+        aggregator.aggregate(programId, singletonList(facility), orderableIds).get();
+
+    assertThat(soh.get(orderableX), is(0));
+    assertThat(soh.containsKey(orderableY), is(false));
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenAnyFacilityLookupFails() {
+    FacilityDto facilityA = facility();
+    FacilityDto facilityB = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facilityA.getId()), anySet(), isNull()))
+        .thenReturn(singletonList(card(orderableX, 100)));
+    when(stockCardSummariesService.search(eq(programId), eq(facilityB.getId()), anySet(), isNull()))
+        .thenThrow(new IllegalStateException("stock service down"));
+
+    Optional<Map<UUID, Integer>> result =
+        aggregator.aggregate(programId, asList(facilityA, facilityB), singleton(orderableX));
+
+    assertThat(result.isPresent(), is(false));
+  }
+
+  @Test
+  public void shouldReturnEmptyWhenSingleFacilityLookupFails() {
+    FacilityDto facility = facility();
+    when(stockCardSummariesService.search(eq(programId), eq(facility.getId()), anySet(), isNull()))
+        .thenThrow(new IllegalStateException("stock service down"));
+
+    Optional<Map<UUID, Integer>> result =
+        aggregator.aggregate(programId, singletonList(facility), singleton(orderableX));
+
+    assertThat(result.isPresent(), is(false));
+  }
+}

--- a/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/RequisitionControllerTest.java
@@ -118,6 +118,7 @@ import org.openlmis.requisition.service.RequisitionService;
 import org.openlmis.requisition.service.RequisitionStatusNotifier;
 import org.openlmis.requisition.service.RequisitionStatusProcessor;
 import org.openlmis.requisition.service.RequisitionTemplateService;
+import org.openlmis.requisition.service.SupplyingFacilityStockService;
 import org.openlmis.requisition.service.referencedata.ApproveProductsAggregator;
 import org.openlmis.requisition.service.referencedata.ApprovedProductReferenceDataService;
 import org.openlmis.requisition.service.referencedata.FacilityReferenceDataService;
@@ -160,6 +161,9 @@ public class RequisitionControllerTest {
 
   @Mock
   private RequisitionService requisitionService;
+
+  @Mock
+  private SupplyingFacilityStockService supplyingFacilityStockService;
 
   @Mock
   private PeriodService periodService;


### PR DESCRIPTION
## Summary

Extends GET /api/requisitions/{id} (V1) so that, for approval-eligible requisitions, the response includes the supplying facilities and the per-line supplying-facility stock on hand. This lets approving officers see the depot's stock during approval. It is display-only and fully gated, and the approve endpoint is untouched.

It covers sections 1, 1.1, 1.2, 1.3, and 3 of the HLD: [Supplying Facility Stock Visibility](https://openlmis.atlassian.net/wiki/spaces/OP/pages/3906732077).

> Stacked on OPSD-98. This branch targets OPSD-98-register-supplying-facility-stock-column and should be retargeted to master once OPSD-98 merges. It relies on the supplyingFacilityStockOnHand template column and the SUPPLYING_FACILITY_STOCK source type added there.

## Changes

- DTOs: a small SupplyingFacilityDto {id, code, name}; supplyingFacilities and supplyingFacilityAccessDenied on BaseRequisitionDto (shared by the V1 and V2 requisition DTOs); supplyingFacilityStockOnHand on BaseRequisitionLineItemDto. All are display-only, not part of the Importer or Exporter, and omitted from JSON when null.
- SupplyingFacilityResolver: turns SupplyLine configuration into the distinct supplying facilities for the requisition's program and current supervisory node.
- SupplyingFacilitySohAggregator: for each resolved facility, fetch stock card summaries with the service account, sum stock on hand across lots, then take the max across facilities. If any lookup fails it returns no values at all, so an under-counted total is never shown; a null summary means no stock card, which stays distinct from 0.
- SupplyingFacilityStockService: the gated orchestration (approval status, template column enabled, caller can approve, resolve facilities, STOCK_CARDS_VIEW at the facility, then fetch), which sets the response fields. It does nothing unless every gate passes, so non-approval reads are byte-identical to before.
- PermissionService: the STOCK_CARDS_VIEW right and a canViewStockCards(facilityId, programId) gate.
- RequisitionController.getRequisition: a one-line enrich call after the DTO is built (V1).

## Decisions (resolved from the HLD)

- Endpoint is V1. HLD section 1 and the ticket both target GET /api/requisitions/{id}, and V2 line items are reference-only, so unusable for the approval grid. The fields live on the shared base DTOs, so wiring V2 later is a one-line change. Batch (ApproveRequisitionDto) is out of scope.
- STOCK_CARDS_VIEW is checked at program and facility, per HLD section 1.3 checkRight(STOCK_CARDS_VIEW, facilityId, programId). If the right is not registered in a deployment, the read degrades gracefully (a WARN, and the feature is not shown) instead of returning 500.
- The source is neither a stock nor a reference source (inherited from OPSD-98): the column has no backing line-item property, so treating it as a stock source would fail the line-item stock invariants.

## Testing

Unit tests cover the resolver (dedup, empty, no supervisory node); the aggregator (sum across lots, max across facilities, 0 vs null, and lookup failure for one and for several facilities); and the full section 1.3 gate table, rows 1 to 7, including access-denied and stock-unavailable, plus the missing-right guard. RequisitionControllerTest stays green with the new collaborator, and the whole unit suite passes.

Integration tests (the acceptance criteria) are still to be added and will run in CI. The integration-test source set does not compile in the local dev image (a javax.interceptor classpath gap that is also present on master), so they can only run in CI. They will cover feature disabled, permission denied, no supplying facility configured, stock service unavailable, single and multiple supplying facilities, and null and 0 stock values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/133)
<!-- Reviewable:end -->
