### PR TITLE
MW-1471: Activate Prometheus metrics endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ repositories {
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-actuator"
+    compile "io.micrometer:micrometer-registry-prometheus"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     compile "net.sf.jasperreports:jasperreports:6.5.1"

--- a/src/main/java/org/openlmis/requisition/security/ResourceServerSecurityConfiguration.java
+++ b/src/main/java/org/openlmis/requisition/security/ResourceServerSecurityConfiguration.java
@@ -87,6 +87,7 @@ public class ResourceServerSecurityConfiguration implements ResourceServerConfig
         .authorizeRequests()
         .antMatchers(
             "/actuator/health",
+            "/actuator/prometheus",
             "/requisition",
             "/webjars/**",
             "/requisition/webjars/**",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,7 +26,8 @@ spring.jpa.properties.hibernate.metadata_builder_contributor=org.openlmis.requis
 
 management.endpoints.enabled-by-default=false
 management.endpoint.health.enabled=true
-management.endpoints.web.exposure.include=health
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health,prometheus
 
 server.compression.enabled=true
 server.compression.mime-types=application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css


### PR DESCRIPTION
Activates the Prometheus (Micrometer) actuator endpoint so JVM and HTTP metrics can be scraped by a Grafana Alloy agent (OpenLMIS Malawi monitoring).

**Changes**
- `build.gradle`: add `io.micrometer:micrometer-registry-prometheus` (actuator starter already present).
- `application.properties`: enable and expose the `prometheus` actuator endpoint (`management.endpoint.prometheus.enabled=true`, added to `management.endpoints.web.exposure.include`).
- `ResourceServerSecurityConfiguration`: permit `/actuator/prometheus` (same treatment as the existing `/actuator/health`), otherwise the resource server returns 401.

**Security**
`/actuator/prometheus` is served on the app port and permitted unauthenticated, mirroring `/actuator/health`. In the Malawi deployment the service ports are not host-published and nginx only routes `/api/*`, so the endpoint is reachable only on the internal Docker network where Alloy scrapes it.

A companion hotfix branch `rel-8.4.0-hotfix.1` carries the same activation on the deployed 8.4.0 line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/134)
<!-- Reviewable:end -->
