### PR TITLE
OPSD-99: return supplying-facility stock from GET /api/v2/requisitions/{id}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 Improvements:
 * [OPSD-99](https://openlmis.atlassian.net/browse/OPSD-99): Return supplying-facility stock on hand and supplying-facility metadata in GET /api/requisitions/{id} for approval-eligible requisitions, gated by the supplyingFacilityStockOnHand template column and STOCK_CARDS_VIEW at the supplying facility (display-only; the approve endpoint is unchanged).
+* [OPSD-99](https://openlmis.atlassian.net/browse/OPSD-99): Return the same supplying-facility stock on hand and metadata from GET /api/v2/requisitions/{id}, so the requisition approval view (which loads through the v2 endpoint) receives the fields.
 * [OPSD-98](https://openlmis.atlassian.net/browse/OPSD-98): Registered the read-only supplyingFacilityStockOnHand requisition-template column (disabled by default, kept out of generated requisition reports).
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Migrated the SonarCloud analysis to Java 21 by running it through the SonarQube scan action instead of the Gradle plugin, and removed the now-unused Gradle sonar plugin and configuration.
 * [OLMIS-8280](https://openlmis.atlassian.net/browse/OLMIS-8280) Removed the axios dependency from the Consul registration script, replacing it with the native Node `http` client (no more axios security advisories to track).

--- a/src/integration-test/java/org/openlmis/requisition/web/RequisitionV2ControllerIntegrationTest.java
+++ b/src/integration-test/java/org/openlmis/requisition/web/RequisitionV2ControllerIntegrationTest.java
@@ -69,11 +69,13 @@ import org.openlmis.requisition.dto.RequisitionLineItemV2Dto;
 import org.openlmis.requisition.dto.RequisitionV2Dto;
 import org.openlmis.requisition.dto.VersionIdentityDto;
 import org.openlmis.requisition.errorhandling.ValidationResult;
+import org.openlmis.requisition.service.SupplyingFacilityStockService;
 import org.openlmis.requisition.service.referencedata.ApproveProductsAggregator;
 import org.openlmis.requisition.testutils.ApprovedProductDtoDataBuilder;
 import org.openlmis.requisition.testutils.OrderableDtoDataBuilder;
 import org.openlmis.requisition.utils.Message;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -94,6 +96,9 @@ public class RequisitionV2ControllerIntegrationTest extends BaseRequisitionWebIn
 
   @Autowired
   private RequisitionV2Controller controller;
+
+  @MockBean
+  private SupplyingFacilityStockService supplyingFacilityStockService;
 
   private List<StockAdjustmentReason> stockAdjustmentReasons;
 
@@ -302,6 +307,33 @@ public class RequisitionV2ControllerIntegrationTest extends BaseRequisitionWebIn
         .body("id", is(requisition.getId().toString()));
 
     // then
+    assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
+  }
+
+  @Test
+  public void shouldEnrichRequisitionWithSupplyingFacilityStock() {
+    // given
+    mockFacility();
+    Requisition requisition = generateRequisition(RequisitionStatus.INITIATED);
+    doReturn(ValidationResult.success())
+        .when(permissionService)
+        .canViewRequisition(requisition);
+
+    generateApprovedProducts(requisition);
+
+    // when
+    restAssured.given()
+        .header(HttpHeaders.AUTHORIZATION, getTokenHeader())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .pathParam("id", requisition.getId())
+        .when()
+        .get(ID_URL)
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // then
+    verify(supplyingFacilityStockService)
+        .enrich(any(Requisition.class), any(RequisitionV2Dto.class));
     assertThat(RAML_ASSERT_MESSAGE, restAssured.getLastReport(), RamlMatchers.hasNoViolations());
   }
 

--- a/src/main/java/org/openlmis/requisition/web/RequisitionV2Controller.java
+++ b/src/main/java/org/openlmis/requisition/web/RequisitionV2Controller.java
@@ -45,6 +45,7 @@ import org.openlmis.requisition.dto.RequisitionV2Dto;
 import org.openlmis.requisition.dto.VersionObjectReferenceDto;
 import org.openlmis.requisition.service.PeriodService;
 import org.openlmis.requisition.service.RequisitionService;
+import org.openlmis.requisition.service.SupplyingFacilityStockService;
 import org.slf4j.profiler.Profiler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -73,6 +74,9 @@ public class RequisitionV2Controller extends BaseRequisitionController {
 
   @Autowired
   private PeriodService periodService;
+
+  @Autowired
+  private SupplyingFacilityStockService supplyingFacilityStockService;
 
   public static final String RESOURCE_URL = API_URL + "/v2/requisitions";
 
@@ -175,6 +179,10 @@ public class RequisitionV2Controller extends BaseRequisitionController {
     checkPermission(profiler, () -> permissionService.canViewRequisition(requisition));
 
     RequisitionV2Dto dto = buildDto(requisition, profiler);
+
+    profiler.start("POPULATE_SUPPLYING_FACILITY_SOH");
+    supplyingFacilityStockService.enrich(requisition, dto);
+
     response.setHeader(HttpHeaders.ETAG, ETagResource.buildWeakETag(requisition.getVersion()));
 
     stopProfiler(profiler, dto);


### PR DESCRIPTION
`GET /api/v2/requisitions/{id}` now returns the supplying-facility fields (`supplyingFacilities`, `supplyingFacilityStockOnHand`, `supplyingFacilityAccessDenied`), matching the v1 read added in OPSD-99.

OPSD-99 wired the enrichment only into the v1 `RequisitionController`, but the requisition approval view loads a single requisition through the v2 endpoint (`requisitionService.get()` calls `/api/v2/requisitions/{id}`). So the fields never reached the view and the SOH column would render empty. This change unblocks the OPSD-100 frontend.

The fix mirrors v1: inject `SupplyingFacilityStockService` into `RequisitionV2Controller` and call `enrich(requisition, dto)` after `buildDto`. `enrich` is internally gated by `isApprovable()`, so it stays a no-op outside approval states, and the approve endpoint is untouched.

Added an integration test that checks `getRequisition` delegates to `enrich`. Main, unit, and integration-test sources compile in the dev image; the test suites run in CI.

Small follow-up to the already-merged OPSD-99 work, kept under the same ticket on a new branch as discussed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/135)
<!-- Reviewable:end -->
