### PR TITLE
[ODRC-130] Report translations changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ==================
 
 Improvements:
+* [ODRC-130](https://openlmis.atlassian.net/browse/ODRC-130): Requisition print is now filled by the report service, so it is translated for the language given by the new `lang` parameter on GET /api/requisitions/{id}/print and carries the global header with the logo.
 * [OPSD-99](https://openlmis.atlassian.net/browse/OPSD-99): Return supplying-facility stock on hand and supplying-facility metadata in GET /api/requisitions/{id} for approval-eligible requisitions, gated by the supplyingFacilityStockOnHand template column and STOCK_CARDS_VIEW at the supplying facility (display-only; the approve endpoint is unchanged).
 * [OPSD-99](https://openlmis.atlassian.net/browse/OPSD-99): Return the same supplying-facility stock on hand and metadata from GET /api/v2/requisitions/{id}, so the requisition approval view (which loads through the v2 endpoint) receives the fields.
 * [OPSD-98](https://openlmis.atlassian.net/browse/OPSD-98): Registered the read-only supplyingFacilityStockOnHand requisition-template column (disabled by default, kept out of generated requisition reports).

--- a/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
+++ b/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
@@ -216,9 +216,6 @@ public class JasperReportsViewService {
     params.put(DATASOURCE, Collections.singletonList(
         RequisitionReportPayloadBuilder.buildReportRecord(reportDto, dateFormat,
             NumberFormat.getCurrencyInstance(getLocaleFromService()))));
-    params.put("columnLabels", RequisitionReportPayloadBuilder.buildColumnLabels(columns));
-    params.put("columnLabelKeys",
-        RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns));
     params.put("requisitionAuthorized", requisition.getStatus().isAuthorized());
     params.put("dateFormat", dateFormat);
     params.put("showInDoses", showInDoses);

--- a/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
+++ b/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
@@ -22,17 +22,21 @@ import static org.openlmis.requisition.i18n.MessageKeys.ERROR_JASPER_FILE_FORMAT
 import static org.openlmis.requisition.i18n.MessageKeys.ERROR_REPORTING_TEMPLATE_PARAMETER_INVALID;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.sql.Connection;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -72,6 +76,8 @@ import org.openlmis.requisition.service.referencedata.FacilityReferenceDataServi
 import org.openlmis.requisition.service.referencedata.GeographicZoneReferenceDataService;
 import org.openlmis.requisition.service.referencedata.PeriodReferenceDataService;
 import org.openlmis.requisition.service.referencedata.ProgramReferenceDataService;
+import org.openlmis.requisition.service.report.ReportService;
+import org.openlmis.requisition.service.report.RequisitionReportPayloadBuilder;
 import org.openlmis.requisition.utils.Message;
 import org.openlmis.requisition.utils.Pagination;
 import org.openlmis.requisition.utils.ReportUtils;
@@ -86,12 +92,17 @@ import org.springframework.stereotype.Service;
 @SuppressWarnings({"PMD.TooManyMethods"})
 public class JasperReportsViewService {
   private static final String DATASOURCE = "datasource";
+  private static final String SUBREPORT_BYTES = "subreport_bytes";
+  private static final String REQUISITION_REPORT_NAME = "requisition";
   private static final String REQUISITION_REPORT_DIR = "/jasperTemplates/requisition.jrxml";
   private static final String REQUISITION_LINE_REPORT_DIR =
       "/jasperTemplates/requisitionLines.jrxml";
 
   @Autowired
   private DataSource replicationDataSource;
+
+  @Autowired
+  private ReportService reportService;
 
   @Autowired
   private RequisitionReportDtoBuilder requisitionReportDtoBuilder;
@@ -182,29 +193,42 @@ public class JasperReportsViewService {
   }
 
   /**
-   * Generate Jasper Report for printing a requisition.
+   * Generate Jasper Report for printing a requisition. Filling is delegated to the report service,
+   * so all parameters have to be JSON serializable.
    *
    * @param requisition requisition for printing the report.
+   * @param showInDoses whether quantities are rendered in doses.
+   * @param lang language the report should be rendered in.
    * @return generated report.
    * @throws JasperReportViewException if there will be any problem with generating the report.
    */
-  public byte[] generateRequisitionReport(Requisition requisition, Boolean showInDoses)
+  public byte[] generateRequisitionReport(Requisition requisition, Boolean showInDoses, String lang)
       throws JasperReportViewException {
     RequisitionReportDto reportDto = requisitionReportDtoBuilder.build(requisition);
     RequisitionTemplate template = requisition.getTemplate();
 
-    Map<String, Object> params = ReportUtils.createParametersMap();
-    params.put("subreport", createCustomizedRequisitionLineSubreport(template,
-        requisition.getStatus()));
-    params.put(DATASOURCE, Collections.singletonList(reportDto));
-    params.put("template", template);
-    params.put("dateFormat", dateFormat);
-    params.put("decimalFormat", createDecimalFormat());
-    params.put("showInDoses", showInDoses);
-    params.put("currencyDecimalFormat",
-        NumberFormat.getCurrencyInstance(getLocaleFromService()));
+    Map<String, RequisitionTemplateColumn> columns = ReportUtils
+        .getSortedTemplateColumnsForPrint(template.viewColumns(), requisition.getStatus());
 
-    return fillAndExportReport(compileReportFromTemplateUrl(REQUISITION_REPORT_DIR), params);
+    Map<String, Object> params = new HashMap<>();
+    params.put(SUBREPORT_BYTES, Base64.getEncoder().encodeToString(
+        serializeReport(compileSubreport(createCustomizedRequisitionLineSubreport(columns)))));
+    params.put(DATASOURCE, Collections.singletonList(
+        RequisitionReportPayloadBuilder.buildReportRecord(reportDto, dateFormat,
+            NumberFormat.getCurrencyInstance(getLocaleFromService()))));
+    params.put("columnLabels", RequisitionReportPayloadBuilder.buildColumnLabels(columns));
+    params.put("columnLabelKeys",
+        RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns));
+    params.put("requisitionAuthorized", requisition.getStatus().isAuthorized());
+    params.put("dateFormat", dateFormat);
+    params.put("showInDoses", showInDoses);
+    params.put("format", "pdf");
+    params.put("lang", lang);
+
+    byte[] compiledTemplate =
+        serializeReport(compileReportFromTemplateUrl(REQUISITION_REPORT_DIR));
+
+    return reportService.generate(REQUISITION_REPORT_NAME, compiledTemplate, params);
   }
 
   /**
@@ -240,16 +264,12 @@ public class JasperReportsViewService {
     return fillAndExportReport(getReportFromTemplateData(jasperTemplate), parameters);
   }
 
-  private JasperDesign createCustomizedRequisitionLineSubreport(RequisitionTemplate template,
-                                                                RequisitionStatus requisitionStatus)
-      throws JasperReportViewException {
+  private JasperDesign createCustomizedRequisitionLineSubreport(
+      Map<String, RequisitionTemplateColumn> columns) throws JasperReportViewException {
     try (InputStream inputStream = getClass().getResourceAsStream(REQUISITION_LINE_REPORT_DIR)) {
       JasperDesign design = JRXmlLoader.load(inputStream);
       JRBand detail = design.getDetailSection().getBands()[0];
       JRBand header = design.getColumnHeader();
-
-      Map<String, RequisitionTemplateColumn> columns =
-          ReportUtils.getSortedTemplateColumnsForPrint(template.viewColumns(), requisitionStatus);
 
       ReportUtils.customizeBandWithTemplateFields(detail, columns, design.getPageWidth(), 9);
       ReportUtils.customizeBandWithTemplateFields(header, columns, design.getPageWidth(), 9);
@@ -259,6 +279,28 @@ public class JasperReportsViewService {
       throw new JasperReportViewException(err, ERROR_IO, err.getMessage());
     } catch (JRException err) {
       throw new JasperReportViewException(err, ERROR_JASPER_FILE_FORMAT, err.getMessage());
+    }
+  }
+
+  private JasperReport compileSubreport(JasperDesign design) throws JasperReportViewException {
+    try {
+      return JasperCompileManager.compileReport(design);
+    } catch (JRException ex) {
+      throw new JasperReportViewException(ex, ERROR_JASPER_FILE_FORMAT, ex.getMessage());
+    }
+  }
+
+  /**
+   * Serializes a compiled report so the report service can read it back.
+   */
+  private byte[] serializeReport(JasperReport report) throws JasperReportViewException {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+         ObjectOutputStream out = new ObjectOutputStream(bos)) {
+      out.writeObject(report);
+      out.flush();
+      return bos.toByteArray();
+    } catch (IOException ex) {
+      throw new JasperReportViewException(ex, ERROR_IO, ex.getMessage());
     }
   }
 

--- a/src/main/java/org/openlmis/requisition/service/report/BaseReportService.java
+++ b/src/main/java/org/openlmis/requisition/service/report/BaseReportService.java
@@ -1,0 +1,36 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.report;
+
+import org.openlmis.requisition.service.BaseCommunicationService;
+import org.springframework.beans.factory.annotation.Value;
+
+public abstract class BaseReportService<T> extends BaseCommunicationService<T> {
+
+  @Value("${report.url}")
+  private String reportUrl;
+
+  @Override
+  protected String getServiceName() {
+    return "Report";
+  }
+
+  @Override
+  protected String getServiceUrl() {
+    return reportUrl;
+  }
+
+}

--- a/src/main/java/org/openlmis/requisition/service/report/GenerateReportDto.java
+++ b/src/main/java/org/openlmis/requisition/service/report/GenerateReportDto.java
@@ -1,0 +1,39 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.report;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Request payload of the report service generate endpoint.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@ToString
+public final class GenerateReportDto {
+  private String name;
+  private byte[] template;
+  private Map<String, Object> params;
+}

--- a/src/main/java/org/openlmis/requisition/service/report/ReportService.java
+++ b/src/main/java/org/openlmis/requisition/service/report/ReportService.java
@@ -1,0 +1,76 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.report;
+
+import static org.openlmis.requisition.utils.RequestHelper.createUri;
+
+import java.util.Map;
+import org.openlmis.requisition.utils.RequestHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpStatusCodeException;
+
+@Service
+public class ReportService extends BaseReportService<byte[]> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReportService.class);
+
+  /**
+   * Sends a compiled report and its parameters to the report service, which fills it with the
+   * shared translation bundle and the global header.
+   *
+   * @param reportName name of the report.
+   * @param reportData serialized compiled report.
+   * @param params report parameters, must be JSON serializable.
+   * @return exported report.
+   */
+  public byte[] generate(String reportName, byte[] reportData, Map<String, Object> params) {
+    String url = getServiceUrl() + getUrl();
+    GenerateReportDto request = new GenerateReportDto(reportName, reportData, params);
+
+    LOGGER.debug("Sending generate report request to Report: {}", reportName);
+
+    try {
+      return runWithRetryAndTokenRetry(() ->
+          restTemplate.exchange(
+              createUri(url),
+              HttpMethod.POST,
+              RequestHelper.createEntity(request, authService.obtainAccessToken()),
+              byte[].class
+          )).getBody();
+
+    } catch (HttpStatusCodeException ex) {
+      throw buildDataRetrievalException(ex);
+    }
+  }
+
+  @Override
+  protected String getUrl() {
+    return "/api/reports/generate";
+  }
+
+  @Override
+  protected Class<byte[]> getResultClass() {
+    return byte[].class;
+  }
+
+  @Override
+  protected Class<byte[][]> getArrayResultClass() {
+    return byte[][].class;
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilder.java
+++ b/src/main/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilder.java
@@ -1,0 +1,213 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.report;
+
+import java.text.NumberFormat;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.joda.money.Money;
+import org.openlmis.requisition.domain.RequisitionTemplateColumn;
+import org.openlmis.requisition.dto.OrderableDto;
+import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.dto.RequisitionLineItemDto;
+import org.openlmis.requisition.dto.RequisitionReportDto;
+import org.openlmis.requisition.dto.UserDto;
+
+/**
+ * Flattens requisition report data into plain maps and scalars, since the payload reaches the
+ * report service as JSON and domain objects would not survive the trip.
+ */
+public final class RequisitionReportPayloadBuilder {
+
+  private static final String COLUMN_KEY_PREFIX = "report.column.requisition.";
+
+  private RequisitionReportPayloadBuilder() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Builds the record backing the requisition report. Dates and money are formatted here because
+   * the formatters cannot be sent to the report service.
+   *
+   * @param reportDto the requisition report data.
+   * @param dateFormat pattern used for dates.
+   * @param currencyFormat format used for monetary values.
+   * @return map of the fields the requisition template declares.
+   */
+  public static Map<String, Object> buildReportRecord(RequisitionReportDto reportDto,
+                                                      String dateFormat,
+                                                      NumberFormat currencyFormat) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat);
+    RequisitionDto requisition = reportDto.getRequisition();
+    UUID programId = requisition.getProgram().getId();
+
+    Map<String, Object> record = new HashMap<>();
+    record.put("facilityName", requisition.getFacility().getName());
+    record.put("facilityCode", requisition.getFacility().getCode());
+    record.put("facilityTypeName", requisition.getFacility().getType().getName());
+    record.put("zoneName", requisition.getFacility().getGeographicZone().getName());
+    record.put("programName", requisition.getProgram().getName());
+    record.put("emergency", requisition.getEmergency());
+    record.put("status", requisition.getStatus().toString());
+    record.put("reportingPeriod",
+        formatter.format(requisition.getProcessingPeriod().getStartDate())
+            + " - " + formatter.format(requisition.getProcessingPeriod().getEndDate()));
+
+    record.put("initiatedBy", printName(reportDto.getInitiatedBy()));
+    record.put("initiatedDate", formatDate(reportDto.getInitiatedDate(), formatter));
+    record.put("submittedBy", printName(reportDto.getSubmittedBy()));
+    record.put("submittedDate", formatDate(reportDto.getSubmittedDate(), formatter));
+    record.put("authorizedBy", printName(reportDto.getAuthorizedBy()));
+    record.put("authorizedDate", formatDate(reportDto.getAuthorizedDate(), formatter));
+
+    record.put("fullSupplyTotalCost",
+        formatMoney(reportDto.getFullSupplyTotalCost(), currencyFormat));
+    record.put("nonFullSupplyTotalCost",
+        formatMoney(reportDto.getNonFullSupplyTotalCost(), currencyFormat));
+    record.put("totalCost", formatMoney(reportDto.getTotalCost(), currencyFormat));
+
+    record.put("fullSupply", buildLineItems(reportDto.getFullSupply(), programId, currencyFormat));
+    record.put("nonFullSupply",
+        buildLineItems(reportDto.getNonFullSupply(), programId, currencyFormat));
+
+    return record;
+  }
+
+  /**
+   * Builds the label the line item subreport falls back to for each column header.
+   *
+   * @param columns the columns that will be printed, in display order.
+   * @return column key to configured label.
+   */
+  public static Map<String, String> buildColumnLabels(
+      Map<String, RequisitionTemplateColumn> columns) {
+    Map<String, String> labels = new LinkedHashMap<>();
+    for (Map.Entry<String, RequisitionTemplateColumn> entry : columns.entrySet()) {
+      labels.put(entry.getKey(), entry.getValue().getLabel());
+    }
+    return labels;
+  }
+
+  /**
+   * Builds the translation key for each column header. A column is only keyed while its label is
+   * still the shipped default, so a label an administrator renamed is printed as entered.
+   *
+   * @param columns the columns that will be printed, in display order.
+   * @return column key to translation key, for columns with an untouched label.
+   */
+  public static Map<String, String> buildColumnLabelKeys(
+      Map<String, RequisitionTemplateColumn> columns) {
+    Map<String, String> keys = new LinkedHashMap<>();
+    for (Map.Entry<String, RequisitionTemplateColumn> entry : columns.entrySet()) {
+      RequisitionTemplateColumn column = entry.getValue();
+      if (usesShippedLabel(column)) {
+        keys.put(entry.getKey(), COLUMN_KEY_PREFIX + column.getName());
+      }
+    }
+    return keys;
+  }
+
+  private static boolean usesShippedLabel(RequisitionTemplateColumn column) {
+    return column.getColumnDefinition() != null
+        && column.getLabel() != null
+        && column.getLabel().equals(column.getColumnDefinition().getLabel());
+  }
+
+  private static List<Map<String, Object>> buildLineItems(List<RequisitionLineItemDto> lineItems,
+                                                          UUID programId,
+                                                          NumberFormat currencyFormat) {
+    List<Map<String, Object>> records = new ArrayList<>();
+    if (lineItems == null) {
+      return records;
+    }
+
+    for (RequisitionLineItemDto lineItem : lineItems) {
+      records.add(buildLineItem(lineItem, programId, currencyFormat));
+    }
+    return records;
+  }
+
+  @SuppressWarnings("PMD.NcssCount")
+  private static Map<String, Object> buildLineItem(RequisitionLineItemDto lineItem,
+                                                   UUID programId,
+                                                   NumberFormat currencyFormat) {
+    Map<String, Object> record = new HashMap<>();
+
+    record.put("beginningBalance", lineItem.getBeginningBalance());
+    record.put("totalReceivedQuantity", lineItem.getTotalReceivedQuantity());
+    record.put("totalLossesAndAdjustments", lineItem.getTotalLossesAndAdjustments());
+    record.put("stockOnHand", lineItem.getStockOnHand());
+    record.put("requestedQuantity", lineItem.getRequestedQuantity());
+    record.put("totalConsumedQuantity", lineItem.getTotalConsumedQuantity());
+    record.put("requestedQuantityExplanation", lineItem.getRequestedQuantityExplanation());
+    record.put("remarks", lineItem.getRemarks());
+    record.put("approvedQuantity", lineItem.getApprovedQuantity());
+    record.put("totalStockoutDays", lineItem.getTotalStockoutDays());
+    record.put("total", lineItem.getTotal());
+    record.put("packsToShip", lineItem.getPacksToShip());
+    record.put("numberOfNewPatientsAdded", lineItem.getNumberOfNewPatientsAdded());
+    record.put("skipped", lineItem.getSkipped());
+    record.put("adjustedConsumption", lineItem.getAdjustedConsumption());
+    record.put("averageConsumption", lineItem.getAverageConsumption());
+    record.put("maximumStockQuantity", lineItem.getMaximumStockQuantity());
+    record.put("calculatedOrderQuantity", lineItem.getCalculatedOrderQuantity());
+    record.put("idealStockAmount", lineItem.getIdealStockAmount());
+    record.put("calculatedOrderQuantityIsa", lineItem.getCalculatedOrderQuantityIsa());
+    record.put("additionalQuantityRequired", lineItem.getAdditionalQuantityRequired());
+    record.put("numberOfPatientsOnTreatmentNextMonth",
+        lineItem.getNumberOfPatientsOnTreatmentNextMonth());
+    record.put("totalRequirement", lineItem.getTotalRequirement());
+    record.put("totalQuantityNeededByHf", lineItem.getTotalQuantityNeededByHf());
+    record.put("quantityToIssue", lineItem.getQuantityToIssue());
+    record.put("convertedQuantityToIssue", lineItem.getConvertedQuantityToIssue());
+    record.put("dosesPerPatient", lineItem.getDosesPerPatient());
+
+    record.put("pricePerPack", formatMoney(lineItem.getPricePerPack(), currencyFormat));
+    record.put("totalCost", formatMoney(lineItem.getTotalCost(), currencyFormat));
+
+    OrderableDto orderable = lineItem.getOrderable();
+    if (orderable != null) {
+      record.put("productCode", orderable.getProductCode());
+      record.put("fullProductName", orderable.getFullProductName());
+      record.put("netContent", orderable.getNetContent());
+      record.put("categoryDisplayName", orderable.getProgramOrderable(programId)
+          .getOrderableCategoryDisplayName());
+      if (orderable.getDispensable() != null) {
+        record.put("dispensableDisplayUnit", orderable.getDispensable().getDisplayUnit());
+      }
+    }
+
+    return record;
+  }
+
+  private static String printName(UserDto user) {
+    return user == null ? null : user.printName();
+  }
+
+  private static String formatDate(ZonedDateTime dateTime, DateTimeFormatter formatter) {
+    return dateTime == null ? null : formatter.format(dateTime.toLocalDate());
+  }
+
+  private static String formatMoney(Money money, NumberFormat currencyFormat) {
+    return money == null ? null : currencyFormat.format(money.getAmount());
+  }
+}

--- a/src/main/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilder.java
+++ b/src/main/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilder.java
@@ -38,7 +38,7 @@ import org.openlmis.requisition.dto.UserDto;
  */
 public final class RequisitionReportPayloadBuilder {
 
-  private static final String COLUMN_KEY_PREFIX = "report.column.requisition.";
+  private static final String COLUMN_KEY_PREFIX = "report.column.";
 
   private RequisitionReportPayloadBuilder() {
     throw new UnsupportedOperationException();

--- a/src/main/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilder.java
+++ b/src/main/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilder.java
@@ -20,12 +20,10 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.joda.money.Money;
-import org.openlmis.requisition.domain.RequisitionTemplateColumn;
 import org.openlmis.requisition.dto.OrderableDto;
 import org.openlmis.requisition.dto.RequisitionDto;
 import org.openlmis.requisition.dto.RequisitionLineItemDto;
@@ -37,8 +35,6 @@ import org.openlmis.requisition.dto.UserDto;
  * report service as JSON and domain objects would not survive the trip.
  */
 public final class RequisitionReportPayloadBuilder {
-
-  private static final String COLUMN_KEY_PREFIX = "report.column.";
 
   private RequisitionReportPayloadBuilder() {
     throw new UnsupportedOperationException();
@@ -60,76 +56,37 @@ public final class RequisitionReportPayloadBuilder {
     RequisitionDto requisition = reportDto.getRequisition();
     UUID programId = requisition.getProgram().getId();
 
-    Map<String, Object> record = new HashMap<>();
-    record.put("facilityName", requisition.getFacility().getName());
-    record.put("facilityCode", requisition.getFacility().getCode());
-    record.put("facilityTypeName", requisition.getFacility().getType().getName());
-    record.put("zoneName", requisition.getFacility().getGeographicZone().getName());
-    record.put("programName", requisition.getProgram().getName());
-    record.put("emergency", requisition.getEmergency());
-    record.put("status", requisition.getStatus().toString());
-    record.put("reportingPeriod",
+    Map<String, Object> reportRecord = new HashMap<>();
+    reportRecord.put("facilityName", requisition.getFacility().getName());
+    reportRecord.put("facilityCode", requisition.getFacility().getCode());
+    reportRecord.put("facilityTypeName", requisition.getFacility().getType().getName());
+    reportRecord.put("zoneName", requisition.getFacility().getGeographicZone().getName());
+    reportRecord.put("programName", requisition.getProgram().getName());
+    reportRecord.put("emergency", requisition.getEmergency());
+    reportRecord.put("status", requisition.getStatus().toString());
+    reportRecord.put("reportingPeriod",
         formatter.format(requisition.getProcessingPeriod().getStartDate())
             + " - " + formatter.format(requisition.getProcessingPeriod().getEndDate()));
 
-    record.put("initiatedBy", printName(reportDto.getInitiatedBy()));
-    record.put("initiatedDate", formatDate(reportDto.getInitiatedDate(), formatter));
-    record.put("submittedBy", printName(reportDto.getSubmittedBy()));
-    record.put("submittedDate", formatDate(reportDto.getSubmittedDate(), formatter));
-    record.put("authorizedBy", printName(reportDto.getAuthorizedBy()));
-    record.put("authorizedDate", formatDate(reportDto.getAuthorizedDate(), formatter));
+    reportRecord.put("initiatedBy", printName(reportDto.getInitiatedBy()));
+    reportRecord.put("initiatedDate", formatDate(reportDto.getInitiatedDate(), formatter));
+    reportRecord.put("submittedBy", printName(reportDto.getSubmittedBy()));
+    reportRecord.put("submittedDate", formatDate(reportDto.getSubmittedDate(), formatter));
+    reportRecord.put("authorizedBy", printName(reportDto.getAuthorizedBy()));
+    reportRecord.put("authorizedDate", formatDate(reportDto.getAuthorizedDate(), formatter));
 
-    record.put("fullSupplyTotalCost",
+    reportRecord.put("fullSupplyTotalCost",
         formatMoney(reportDto.getFullSupplyTotalCost(), currencyFormat));
-    record.put("nonFullSupplyTotalCost",
+    reportRecord.put("nonFullSupplyTotalCost",
         formatMoney(reportDto.getNonFullSupplyTotalCost(), currencyFormat));
-    record.put("totalCost", formatMoney(reportDto.getTotalCost(), currencyFormat));
+    reportRecord.put("totalCost", formatMoney(reportDto.getTotalCost(), currencyFormat));
 
-    record.put("fullSupply", buildLineItems(reportDto.getFullSupply(), programId, currencyFormat));
-    record.put("nonFullSupply",
+    reportRecord.put("fullSupply",
+        buildLineItems(reportDto.getFullSupply(), programId, currencyFormat));
+    reportRecord.put("nonFullSupply",
         buildLineItems(reportDto.getNonFullSupply(), programId, currencyFormat));
 
-    return record;
-  }
-
-  /**
-   * Builds the label the line item subreport falls back to for each column header.
-   *
-   * @param columns the columns that will be printed, in display order.
-   * @return column key to configured label.
-   */
-  public static Map<String, String> buildColumnLabels(
-      Map<String, RequisitionTemplateColumn> columns) {
-    Map<String, String> labels = new LinkedHashMap<>();
-    for (Map.Entry<String, RequisitionTemplateColumn> entry : columns.entrySet()) {
-      labels.put(entry.getKey(), entry.getValue().getLabel());
-    }
-    return labels;
-  }
-
-  /**
-   * Builds the translation key for each column header. A column is only keyed while its label is
-   * still the shipped default, so a label an administrator renamed is printed as entered.
-   *
-   * @param columns the columns that will be printed, in display order.
-   * @return column key to translation key, for columns with an untouched label.
-   */
-  public static Map<String, String> buildColumnLabelKeys(
-      Map<String, RequisitionTemplateColumn> columns) {
-    Map<String, String> keys = new LinkedHashMap<>();
-    for (Map.Entry<String, RequisitionTemplateColumn> entry : columns.entrySet()) {
-      RequisitionTemplateColumn column = entry.getValue();
-      if (usesShippedLabel(column)) {
-        keys.put(entry.getKey(), COLUMN_KEY_PREFIX + column.getName());
-      }
-    }
-    return keys;
-  }
-
-  private static boolean usesShippedLabel(RequisitionTemplateColumn column) {
-    return column.getColumnDefinition() != null
-        && column.getLabel() != null
-        && column.getLabel().equals(column.getColumnDefinition().getLabel());
+    return reportRecord;
   }
 
   private static List<Map<String, Object>> buildLineItems(List<RequisitionLineItemDto> lineItems,
@@ -150,53 +107,53 @@ public final class RequisitionReportPayloadBuilder {
   private static Map<String, Object> buildLineItem(RequisitionLineItemDto lineItem,
                                                    UUID programId,
                                                    NumberFormat currencyFormat) {
-    Map<String, Object> record = new HashMap<>();
+    Map<String, Object> lineItemRecord = new HashMap<>();
 
-    record.put("beginningBalance", lineItem.getBeginningBalance());
-    record.put("totalReceivedQuantity", lineItem.getTotalReceivedQuantity());
-    record.put("totalLossesAndAdjustments", lineItem.getTotalLossesAndAdjustments());
-    record.put("stockOnHand", lineItem.getStockOnHand());
-    record.put("requestedQuantity", lineItem.getRequestedQuantity());
-    record.put("totalConsumedQuantity", lineItem.getTotalConsumedQuantity());
-    record.put("requestedQuantityExplanation", lineItem.getRequestedQuantityExplanation());
-    record.put("remarks", lineItem.getRemarks());
-    record.put("approvedQuantity", lineItem.getApprovedQuantity());
-    record.put("totalStockoutDays", lineItem.getTotalStockoutDays());
-    record.put("total", lineItem.getTotal());
-    record.put("packsToShip", lineItem.getPacksToShip());
-    record.put("numberOfNewPatientsAdded", lineItem.getNumberOfNewPatientsAdded());
-    record.put("skipped", lineItem.getSkipped());
-    record.put("adjustedConsumption", lineItem.getAdjustedConsumption());
-    record.put("averageConsumption", lineItem.getAverageConsumption());
-    record.put("maximumStockQuantity", lineItem.getMaximumStockQuantity());
-    record.put("calculatedOrderQuantity", lineItem.getCalculatedOrderQuantity());
-    record.put("idealStockAmount", lineItem.getIdealStockAmount());
-    record.put("calculatedOrderQuantityIsa", lineItem.getCalculatedOrderQuantityIsa());
-    record.put("additionalQuantityRequired", lineItem.getAdditionalQuantityRequired());
-    record.put("numberOfPatientsOnTreatmentNextMonth",
+    lineItemRecord.put("beginningBalance", lineItem.getBeginningBalance());
+    lineItemRecord.put("totalReceivedQuantity", lineItem.getTotalReceivedQuantity());
+    lineItemRecord.put("totalLossesAndAdjustments", lineItem.getTotalLossesAndAdjustments());
+    lineItemRecord.put("stockOnHand", lineItem.getStockOnHand());
+    lineItemRecord.put("requestedQuantity", lineItem.getRequestedQuantity());
+    lineItemRecord.put("totalConsumedQuantity", lineItem.getTotalConsumedQuantity());
+    lineItemRecord.put("requestedQuantityExplanation", lineItem.getRequestedQuantityExplanation());
+    lineItemRecord.put("remarks", lineItem.getRemarks());
+    lineItemRecord.put("approvedQuantity", lineItem.getApprovedQuantity());
+    lineItemRecord.put("totalStockoutDays", lineItem.getTotalStockoutDays());
+    lineItemRecord.put("total", lineItem.getTotal());
+    lineItemRecord.put("packsToShip", lineItem.getPacksToShip());
+    lineItemRecord.put("numberOfNewPatientsAdded", lineItem.getNumberOfNewPatientsAdded());
+    lineItemRecord.put("skipped", lineItem.getSkipped());
+    lineItemRecord.put("adjustedConsumption", lineItem.getAdjustedConsumption());
+    lineItemRecord.put("averageConsumption", lineItem.getAverageConsumption());
+    lineItemRecord.put("maximumStockQuantity", lineItem.getMaximumStockQuantity());
+    lineItemRecord.put("calculatedOrderQuantity", lineItem.getCalculatedOrderQuantity());
+    lineItemRecord.put("idealStockAmount", lineItem.getIdealStockAmount());
+    lineItemRecord.put("calculatedOrderQuantityIsa", lineItem.getCalculatedOrderQuantityIsa());
+    lineItemRecord.put("additionalQuantityRequired", lineItem.getAdditionalQuantityRequired());
+    lineItemRecord.put("numberOfPatientsOnTreatmentNextMonth",
         lineItem.getNumberOfPatientsOnTreatmentNextMonth());
-    record.put("totalRequirement", lineItem.getTotalRequirement());
-    record.put("totalQuantityNeededByHf", lineItem.getTotalQuantityNeededByHf());
-    record.put("quantityToIssue", lineItem.getQuantityToIssue());
-    record.put("convertedQuantityToIssue", lineItem.getConvertedQuantityToIssue());
-    record.put("dosesPerPatient", lineItem.getDosesPerPatient());
+    lineItemRecord.put("totalRequirement", lineItem.getTotalRequirement());
+    lineItemRecord.put("totalQuantityNeededByHf", lineItem.getTotalQuantityNeededByHf());
+    lineItemRecord.put("quantityToIssue", lineItem.getQuantityToIssue());
+    lineItemRecord.put("convertedQuantityToIssue", lineItem.getConvertedQuantityToIssue());
+    lineItemRecord.put("dosesPerPatient", lineItem.getDosesPerPatient());
 
-    record.put("pricePerPack", formatMoney(lineItem.getPricePerPack(), currencyFormat));
-    record.put("totalCost", formatMoney(lineItem.getTotalCost(), currencyFormat));
+    lineItemRecord.put("pricePerPack", formatMoney(lineItem.getPricePerPack(), currencyFormat));
+    lineItemRecord.put("totalCost", formatMoney(lineItem.getTotalCost(), currencyFormat));
 
     OrderableDto orderable = lineItem.getOrderable();
     if (orderable != null) {
-      record.put("productCode", orderable.getProductCode());
-      record.put("fullProductName", orderable.getFullProductName());
-      record.put("netContent", orderable.getNetContent());
-      record.put("categoryDisplayName", orderable.getProgramOrderable(programId)
+      lineItemRecord.put("productCode", orderable.getProductCode());
+      lineItemRecord.put("fullProductName", orderable.getFullProductName());
+      lineItemRecord.put("netContent", orderable.getNetContent());
+      lineItemRecord.put("categoryDisplayName", orderable.getProgramOrderable(programId)
           .getOrderableCategoryDisplayName());
       if (orderable.getDispensable() != null) {
-        record.put("dispensableDisplayUnit", orderable.getDispensable().getDisplayUnit());
+        lineItemRecord.put("dispensableDisplayUnit", orderable.getDispensable().getDisplayUnit());
       }
     }
 
-    return record;
+    return lineItemRecord;
   }
 
   private static String printName(UserDto user) {

--- a/src/main/java/org/openlmis/requisition/web/ReportsController.java
+++ b/src/main/java/org/openlmis/requisition/web/ReportsController.java
@@ -51,6 +51,8 @@ public class ReportsController extends BaseController {
    * Print out requisition as a PDF file.
    *
    * @param id The UUID of the requisition to print
+   * @param showInDoses whether quantities should be rendered in doses
+   * @param lang language tag the report should be rendered in
    * @return ResponseEntity with the "#200 OK" HTTP response status and PDF file on success, or
    *     ResponseEntity containing the error description status.
    */
@@ -58,7 +60,8 @@ public class ReportsController extends BaseController {
   @ResponseBody
   public ResponseEntity<byte[]> print(@PathVariable("id") UUID id,
                                       @RequestParam(required = false, defaultValue = "true")
-                                      Boolean showInDoses)
+                                      Boolean showInDoses,
+                                      @RequestParam(defaultValue = "en") String lang)
       throws JasperReportViewException {
     permissionService.canViewRequisition(id).throwExceptionIfHasErrors();
 
@@ -66,7 +69,8 @@ public class ReportsController extends BaseController {
         .orElseThrow(() -> new ContentNotFoundMessageException(
             new Message(MessageKeys.ERROR_REQUISITION_NOT_FOUND, id)));
 
-    byte[] bytes = jasperReportsViewService.generateRequisitionReport(requisition, showInDoses);
+    byte[] bytes = jasperReportsViewService
+        .generateRequisitionReport(requisition, showInDoses, lang);
 
     return ResponseEntity
         .ok()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -66,6 +66,7 @@ referencedata.url=${BASE_URL}
 fulfillment.url=${BASE_URL}
 notification.url=${BASE_URL}
 stockmanagement.url=${BASE_URL}
+report.url=${BASE_URL}
 
 requisitionUri=${REQUISITION_URI:/#!/requisition/{0}/fullSupply}
 

--- a/src/main/resources/jasperTemplates/requisition.jrxml
+++ b/src/main/resources/jasperTemplates/requisition.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.5.final using JasperReports Library version 6.20.5-3efcf2e67f959db3888d79f73dde2dbd7acb4f8e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisition" pageWidth="1165" pageHeight="595" orientation="Landscape" whenNoDataType="BlankPage" columnWidth="1000" leftMargin="0" rightMargin="0" topMargin="20" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Empty" uuid="a0a4e861-0726-422f-b3d5-54b1aefe96ce">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisition" pageWidth="1165" pageHeight="595" orientation="Landscape" whenNoDataType="BlankPage" columnWidth="1000" leftMargin="0" rightMargin="0" topMargin="20" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Key" uuid="a0a4e861-0726-422f-b3d5-54b1aefe96ce">
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="9"/>
 	<property name="ireport.y" value="0"/>
@@ -12,196 +12,196 @@
 	<import value="java.lang.*"/>
 	<import value="net.sf.jasperreports.engine.*"/>
 	<import value="java.text.DecimalFormat"/>
-	<import value="org.openlmis.requisition.dto.*"/>
-	<import value="org.joda.money.*"/>
 	<import value="net.sf.jasperreports.engine.data.*"/>
-	<import value="java.text.NumberFormat"/>
-	<import value="java.util.stream.*"/>
 	<import value="net.sf.jasperreports.engine.design.*"/>
-	<import value="java.math.BigDecimal"/>
-	<import value="org.springframework.context.i18n.*"/>
 	<import value="java.util.*"/>
 	<import value="java.time.LocalDate"/>
 	<import value="java.time.format.DateTimeFormatter"/>
-	<parameter name="template" class="org.openlmis.requisition.domain.RequisitionTemplate" isForPrompting="false">
-		<property name="displayName" value="template"/>
+	<parameter name="subreport" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false">
+		<property name="displayName" value="subreport"/>
 	</parameter>
-	<parameter name="subreport" class="net.sf.jasperreports.engine.design.JasperDesign" isForPrompting="false">
-		<property name="displayName" value="subreport directory"/>
-	</parameter>
-	<parameter name="currencyDecimalFormat" class="java.text.NumberFormat" isForPrompting="false">
-		<property name="displayName" value="CurrencyDecimalFormat"/>
+	<parameter name="headerTemplate" class="net.sf.jasperreports.engine.JasperReport" isForPrompting="false">
+		<property name="displayName" value="HeaderTemplate"/>
 	</parameter>
 	<parameter name="dateFormat" class="java.lang.String" isForPrompting="false">
 		<property name="displayName" value="dateFormat"/>
 	</parameter>
-	<parameter name="decimalFormat" class="java.text.DecimalFormat" isForPrompting="false">
-		<property name="displayName" value="decimalFormat"/>
-	</parameter>
-	<parameter name="showInDoses" class="java.lang.Boolean" isForPrompting="false"/>
 	<queryString language="SQL">
 		<![CDATA[]]>
 	</queryString>
 	<field name="nonFullSupply" class="java.util.List">
 		<fieldDescription><![CDATA[nonFullSupply]]></fieldDescription>
 	</field>
-	<field name="requisition" class="org.openlmis.requisition.dto.RequisitionDto">
-		<fieldDescription><![CDATA[requisition]]></fieldDescription>
-	</field>
 	<field name="fullSupply" class="java.util.List">
 		<fieldDescription><![CDATA[fullSupply]]></fieldDescription>
 	</field>
-	<field name="fullSupplyTotalCost" class="org.joda.money.Money"/>
-	<field name="nonFullSupplyTotalCost" class="org.joda.money.Money"/>
-	<field name="totalCost" class="org.joda.money.Money"/>
-	<field name="initiatedBy" class="org.openlmis.requisition.dto.UserDto"/>
-	<field name="initiatedDate" class="java.time.ZonedDateTime"/>
-	<field name="submittedBy" class="org.openlmis.requisition.dto.UserDto"/>
-	<field name="submittedDate" class="java.time.ZonedDateTime"/>
-	<field name="authorizedBy" class="org.openlmis.requisition.dto.UserDto"/>
-	<field name="authorizedDate" class="java.time.ZonedDateTime"/>
+	<field name="facilityName" class="java.lang.String"/>
+	<field name="facilityCode" class="java.lang.String"/>
+	<field name="facilityTypeName" class="java.lang.String"/>
+	<field name="zoneName" class="java.lang.String"/>
+	<field name="programName" class="java.lang.String"/>
+	<field name="emergency" class="java.lang.Boolean"/>
+	<field name="status" class="java.lang.String"/>
+	<field name="reportingPeriod" class="java.lang.String"/>
+	<field name="fullSupplyTotalCost" class="java.lang.String"/>
+	<field name="nonFullSupplyTotalCost" class="java.lang.String"/>
+	<field name="totalCost" class="java.lang.String"/>
+	<field name="initiatedBy" class="java.lang.String"/>
+	<field name="initiatedDate" class="java.lang.String"/>
+	<field name="submittedBy" class="java.lang.String"/>
+	<field name="submittedDate" class="java.lang.String"/>
+	<field name="authorizedBy" class="java.lang.String"/>
+	<field name="authorizedDate" class="java.lang.String"/>
 	<background>
 		<band splitType="Stretch"/>
 	</background>
 	<title>
-		<band height="90">
+		<band height="180">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
+			<subreport overflowType="Stretch">
+				<reportElement positionType="Float" mode="Transparent" x="0" y="0" width="1160" height="90" isRemoveLineWhenBlank="true" isPrintWhenDetailOverflows="true" uuid="57924a28-dd0b-4ed5-8b5c-8867c356fb34">
+					<property name="com.jaspersoft.studio.unit.x" value="pixel"/>
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
+				<parametersMapExpression><![CDATA[$P{REPORT_PARAMETERS_MAP}]]></parametersMapExpression>
+				<connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+				<subreportExpression><![CDATA[$P{headerTemplate}]]></subreportExpression>
+			</subreport>
 			<textField isStretchWithOverflow="true">
-				<reportElement x="20" y="10" width="909" height="20" uuid="8b895ad8-e565-41e4-87f4-fe70fea7b9f1"/>
+				<reportElement x="20" y="100" width="909" height="20" uuid="8b895ad8-e565-41e4-87f4-fe70fea7b9f1"/>
 				<textElement verticalAlignment="Middle">
 					<font size="14" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[MessageFormat.format("Report and Requisition for: {0} ({1})", $F{requisition}.getProgram().getName(), $F{requisition}.getFacility().getType().getName())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[msg($R{report.header.reportAndRequisitionFor}, $F{programName}, $F{facilityTypeName})]]></textFieldExpression>
 			</textField>
 			<rectangle>
-				<reportElement mode="Opaque" x="10" y="35" width="1142" height="50" backcolor="#C0C0C0" uuid="65fe1d4d-8334-48d2-b383-ee533c8d5742"/>
+				<reportElement mode="Opaque" x="10" y="125" width="1142" height="50" backcolor="#C0C0C0" uuid="65fe1d4d-8334-48d2-b383-ee533c8d5742"/>
 				<graphicElement>
 					<pen lineWidth="0.0"/>
 				</graphicElement>
 			</rectangle>
 			<textField isStretchWithOverflow="true">
-				<reportElement x="480" y="45" width="130" height="10" uuid="d7a846a8-1be2-4c95-b8b6-eb97381c5fd7"/>
+				<reportElement x="480" y="135" width="130" height="10" uuid="d7a846a8-1be2-4c95-b8b6-eb97381c5fd7"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[DateTimeFormatter.ofPattern($P{dateFormat}).format($F{initiatedDate}.toLocalDate())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{initiatedDate}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="495" y="65" width="115" height="10" uuid="a32b06c8-fec6-4c4e-b229-7e98a0f51657"/>
+				<reportElement x="495" y="155" width="115" height="10" uuid="a32b06c8-fec6-4c4e-b229-7e98a0f51657"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[DateTimeFormatter.ofPattern($P{dateFormat}).format($F{requisition}.getProcessingPeriod().getStartDate())
-           + " - " + DateTimeFormatter.ofPattern($P{dateFormat}).format($F{requisition}.getProcessingPeriod().getEndDate())]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{reportingPeriod}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="665" y="45" width="135" height="10" uuid="dc6a243b-b839-45f3-a08d-fe49ee03f8cc"/>
+				<reportElement x="665" y="135" width="135" height="10" uuid="dc6a243b-b839-45f3-a08d-fe49ee03f8cc"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{requisition}.getEmergency() ? "Emergency" : "Regular"]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{emergency} ? $R{report.value.emergency} : $R{report.value.regular}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="670" y="65" width="130" height="10" uuid="782089a4-e67c-455d-8f34-1218321f5085"/>
+				<reportElement x="670" y="155" width="130" height="10" uuid="782089a4-e67c-455d-8f34-1218321f5085"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{requisition}.getStatus().toString()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{status}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="235" y="65" width="150" height="10" uuid="0f2769f3-2106-4235-9230-012100b3c3de"/>
+				<reportElement x="235" y="155" width="150" height="10" uuid="0f2769f3-2106-4235-9230-012100b3c3de"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{requisition}.getFacility().getGeographicZone().getName()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{zoneName}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="250" y="45" width="135" height="10" uuid="7b42fd08-8189-4b19-8710-aa7571f34137"/>
+				<reportElement x="250" y="135" width="135" height="10" uuid="7b42fd08-8189-4b19-8710-aa7571f34137"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{requisition}.getProgram().getName()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{programName}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="55" y="45" width="130" height="10" uuid="97807c17-6feb-44db-b0ec-eb1fdb21aa21"/>
+				<reportElement x="55" y="135" width="130" height="10" uuid="97807c17-6feb-44db-b0ec-eb1fdb21aa21"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{requisition}.getFacility().getName()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{facilityName}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
-				<reportElement x="75" y="65" width="110" height="10" uuid="eb29697d-1d2f-42b6-9b25-2e2bcdadc080"/>
+				<reportElement x="75" y="155" width="110" height="10" uuid="eb29697d-1d2f-42b6-9b25-2e2bcdadc080"/>
 				<textElement textAlignment="Left">
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{requisition}.getFacility().getCode()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{facilityCode}]]></textFieldExpression>
 			</textField>
-			<staticText>
-				<reportElement x="20" y="45" width="35" height="10" uuid="9ff435e1-2db7-4309-8a64-0111b0a6decb">
+			<textField>
+				<reportElement x="20" y="135" width="35" height="10" uuid="9ff435e1-2db7-4309-8a64-0111b0a6decb">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Facility:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="20" y="65" width="55" height="10" uuid="7e9768e7-2cc9-4f1b-814f-865b39566a13"/>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.facility})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="20" y="155" width="55" height="10" uuid="7e9768e7-2cc9-4f1b-814f-865b39566a13"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Facility code:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="210" y="45" width="40" height="10" uuid="bfb9d50e-e0e4-46cc-aa4a-ea1a0f52b906">
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.facilityCode})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="210" y="135" width="40" height="10" uuid="bfb9d50e-e0e4-46cc-aa4a-ea1a0f52b906">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Program:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="210" y="65" width="25" height="10" uuid="4b3a6dad-2836-4ee3-bc07-2a1da8e16314">
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.program})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="210" y="155" width="25" height="10" uuid="4b3a6dad-2836-4ee3-bc07-2a1da8e16314">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Zone:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="420" y="45" width="60" height="10" uuid="f01ca8e1-24ca-4e6e-8ae5-148769220580"/>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.zone})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="420" y="135" width="60" height="10" uuid="f01ca8e1-24ca-4e6e-8ae5-148769220580"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Creation date:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="420" y="65" width="75" height="10" uuid="8195bd81-f503-402c-99fd-79861348d2ec">
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.creationDate})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="420" y="155" width="75" height="10" uuid="8195bd81-f503-402c-99fd-79861348d2ec">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Reporting period:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="640" y="45" width="25" height="10" uuid="150c310a-e719-4dfa-a6d3-000dd5f634ac">
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.reportingPeriod})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="640" y="135" width="25" height="10" uuid="150c310a-e719-4dfa-a6d3-000dd5f634ac">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Type:]]></text>
-			</staticText>
-			<staticText>
-				<reportElement x="640" y="65" width="30" height="10" uuid="5a51fb8c-f965-48ea-9f59-7a04b8ea4688"/>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.type})]]></textFieldExpression>
+			</textField>
+			<textField>
+				<reportElement x="640" y="155" width="30" height="10" uuid="5a51fb8c-f965-48ea-9f59-7a04b8ea4688"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<text><![CDATA[Status:]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.header.status})]]></textFieldExpression>
+			</textField>
 		</band>
 	</title>
 	<detail>
@@ -210,64 +210,24 @@
 				<reportElement key="fullSupplySubreport" x="0" y="0" width="1160" height="40" uuid="4475ef7c-a24a-4301-812c-f41869743f79">
 					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
 				</reportElement>
-				<subreportParameter name="template">
-					<subreportParameterExpression><![CDATA[$P{template}]]></subreportParameterExpression>
-				</subreportParameter>
+				<parametersMapExpression><![CDATA[$P{REPORT_PARAMETERS_MAP}]]></parametersMapExpression>
 				<subreportParameter name="title">
-					<subreportParameterExpression><![CDATA["Full supply items"]]></subreportParameterExpression>
+					<subreportParameterExpression><![CDATA[$R{report.title.fullSupplyItems}]]></subreportParameterExpression>
 				</subreportParameter>
-				<subreportParameter name="requisitionStatus">
-					<subreportParameterExpression><![CDATA[$F{requisition}.getStatus()]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="programId">
-					<subreportParameterExpression><![CDATA[$F{requisition}.getProgram().getId()]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="dateFormat">
-					<subreportParameterExpression><![CDATA[$P{dateFormat}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="decimalFormat">
-					<subreportParameterExpression><![CDATA[$P{decimalFormat}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="currencyDecimalFormat">
-					<subreportParameterExpression><![CDATA[$P{currencyDecimalFormat}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="showInDoses">
-					<subreportParameterExpression><![CDATA[$P{showInDoses}]]></subreportParameterExpression>
-				</subreportParameter>
-				<dataSourceExpression><![CDATA[new JRBeanCollectionDataSource($F{fullSupply})]]></dataSourceExpression>
-				<subreportExpression><![CDATA[JasperCompileManager.compileReport($P{subreport})]]></subreportExpression>
+				<dataSourceExpression><![CDATA[new JRMapCollectionDataSource($F{fullSupply})]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{subreport}]]></subreportExpression>
 			</subreport>
 			<subreport>
 				<reportElement key="nonFullSupplySubreport" positionType="Float" x="0" y="40" width="1160" height="40" uuid="c5a8dc95-8635-4a3c-9fca-38e46ac77ab8">
 					<property name="com.jaspersoft.studio.unit.y" value="pixel"/>
 					<printWhenExpression><![CDATA[!$F{nonFullSupply}.isEmpty()]]></printWhenExpression>
 				</reportElement>
-				<subreportParameter name="template">
-					<subreportParameterExpression><![CDATA[$P{template}]]></subreportParameterExpression>
-				</subreportParameter>
+				<parametersMapExpression><![CDATA[$P{REPORT_PARAMETERS_MAP}]]></parametersMapExpression>
 				<subreportParameter name="title">
-					<subreportParameterExpression><![CDATA["Non-full supply items"]]></subreportParameterExpression>
+					<subreportParameterExpression><![CDATA[$R{report.title.nonFullSupplyItems}]]></subreportParameterExpression>
 				</subreportParameter>
-				<subreportParameter name="requisitionStatus">
-					<subreportParameterExpression><![CDATA[$F{requisition}.getStatus()]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="programId">
-					<subreportParameterExpression><![CDATA[$F{requisition}.getProgram().getId()]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="dateFormat">
-					<subreportParameterExpression><![CDATA[$P{dateFormat}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="decimalFormat">
-					<subreportParameterExpression><![CDATA[$P{decimalFormat}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="currencyDecimalFormat">
-					<subreportParameterExpression><![CDATA[$P{currencyDecimalFormat}]]></subreportParameterExpression>
-				</subreportParameter>
-				<subreportParameter name="$P{showInDoses}">
-					<subreportParameterExpression><![CDATA[]]></subreportParameterExpression>
-				</subreportParameter>
-				<dataSourceExpression><![CDATA[new JRBeanCollectionDataSource($F{nonFullSupply})]]></dataSourceExpression>
-				<subreportExpression><![CDATA[JasperCompileManager.compileReport($P{subreport})]]></subreportExpression>
+				<dataSourceExpression><![CDATA[new JRMapCollectionDataSource($F{nonFullSupply})]]></dataSourceExpression>
+				<subreportExpression><![CDATA[$P{subreport}]]></subreportExpression>
 			</subreport>
 		</band>
 	</detail>
@@ -281,14 +241,14 @@
 				<textElement textAlignment="Right">
 					<font size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA["Page " + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[msg($R{report.controls.pageNumber}, $V{PAGE_NUMBER})]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
 				<reportElement x="800" y="10" width="30" height="10" uuid="5ded44a2-6687-46fd-b29e-205ba278ca50"/>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA["of " + $V{PAGE_NUMBER}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[msg($R{report.controls.pageTotal}, $V{PAGE_NUMBER})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true">
 				<reportElement positionType="Float" x="10" y="10" width="80" height="10" uuid="2dd094dc-e4b5-43c0-89ab-02f2dda79bb5">
@@ -306,87 +266,86 @@
 	<summary>
 		<band height="170">
 			<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
-			<staticText>
+			<textField>
 				<reportElement key="summaryLabel" x="10" y="10" width="930" height="20" uuid="d91c61a5-4f51-4610-ac52-e058a2957ddb"/>
 				<textElement verticalAlignment="Middle">
 					<font size="14" isBold="true"/>
 				</textElement>
-				<text><![CDATA[Summary]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{report.title.summary}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="20" y="40" width="130" height="10" uuid="a035b2b6-8c32-4db2-89fd-6444a109b1d7"/>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<text><![CDATA[Total Cost for Full Supply Items]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{report.summary.totalCostFullSupply}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="20" y="60" width="150" height="10" uuid="ec47a93b-983c-447f-85cf-4775e800330a"/>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<text><![CDATA[Total Cost for Non Full Supply Items]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[$R{report.summary.totalCostNonFullSupply}]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="20" y="80" width="50" height="10" uuid="08e7b43c-4f44-4e33-88f6-92324585772e"/>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<text><![CDATA[Total Cost]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[$R{report.summary.totalCost}]]></textFieldExpression>
+			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
 				<reportElement x="250" y="40" width="240" height="10" uuid="35a72954-5841-4f9b-abf2-711eea0bd17f"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{currencyDecimalFormat}.format(new BigDecimal($F{fullSupplyTotalCost}.toString().replaceAll("[^0-9?!\\.]+", ""))).toString()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{fullSupplyTotalCost}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
 				<reportElement x="250" y="60" width="240" height="10" uuid="a6e8c1b3-5480-4e60-a44a-0c1c29e21473"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{currencyDecimalFormat}.format(new BigDecimal($F{nonFullSupplyTotalCost}.toString().replaceAll("[^0-9?!\\.]+", ""))).toString()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{nonFullSupplyTotalCost}]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
 				<reportElement x="250" y="80" width="240" height="10" uuid="526378e0-d374-40c9-a7ec-3a20c4337a25"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{currencyDecimalFormat}.format(new BigDecimal($F{totalCost}.toString().replaceAll("[^0-9?!\\.]+", ""))).toString()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{totalCost}]]></textFieldExpression>
 			</textField>
-			<staticText>
+			<textField>
 				<reportElement x="20" y="110" width="60" height="10" uuid="c7929aee-d4b2-4b69-86ea-26ffd9ea0be0"/>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<text><![CDATA[Created by:]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.summary.createdBy})]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="20" y="130" width="60" height="10" uuid="09833b2c-ae0d-4a34-a608-bfeaf297a414">
 					<printWhenExpression><![CDATA[$F{submittedBy} != null]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<text><![CDATA[Submitted by:]]></text>
-			</staticText>
-			<staticText>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.summary.submittedBy})]]></textFieldExpression>
+			</textField>
+			<textField>
 				<reportElement x="20" y="150" width="60" height="10" uuid="9544c075-f57c-4a86-8d1b-6a21f3a93963">
 					<printWhenExpression><![CDATA[$F{authorizedBy} != null]]></printWhenExpression>
 				</reportElement>
 				<textElement>
 					<font size="8"/>
 				</textElement>
-				<text><![CDATA[Authorized by:]]></text>
-			</staticText>
+				<textFieldExpression><![CDATA[msg($R{report.pattern.label}, $R{report.summary.authorizedBy})]]></textFieldExpression>
+			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
 				<reportElement x="140" y="110" width="350" height="10" uuid="d95d5f81-476d-4445-a53c-5ebee7846625"/>
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[MessageFormat.format("{0} on {1}", $F{initiatedBy}.printName(),
-														DateTimeFormatter.ofPattern($P{dateFormat}).format($F{initiatedDate}.toLocalDate()))]]></textFieldExpression>
+				<textFieldExpression><![CDATA[msg($R{report.message.userOnDate}, $F{initiatedBy}, $F{initiatedDate})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
 				<reportElement x="140" y="130" width="350" height="10" uuid="ffd6b808-1a5a-4b04-aa73-cd434c8c1bdf">
@@ -395,8 +354,7 @@
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[MessageFormat.format("{0} on {1}", $F{submittedBy}.printName(),
-														DateTimeFormatter.ofPattern($P{dateFormat}).format($F{submittedDate}.toLocalDate()))]]></textFieldExpression>
+				<textFieldExpression><![CDATA[msg($R{report.message.userOnDate}, $F{submittedBy}, $F{submittedDate})]]></textFieldExpression>
 			</textField>
 			<textField isStretchWithOverflow="true" pattern="">
 				<reportElement x="140" y="150" width="350" height="10" uuid="4372bf9c-feff-4449-8944-1726d7d65d43">
@@ -405,8 +363,7 @@
 				<textElement>
 					<font size="8" isBold="false"/>
 				</textElement>
-				<textFieldExpression><![CDATA[MessageFormat.format("{0} on {1}", $F{authorizedBy}.printName(),
-														DateTimeFormatter.ofPattern($P{dateFormat}).format($F{authorizedDate}.toLocalDate()))]]></textFieldExpression>
+				<textFieldExpression><![CDATA[msg($R{report.message.userOnDate}, $F{authorizedBy}, $F{authorizedDate})]]></textFieldExpression>
 			</textField>
 		</band>
 	</summary>

--- a/src/main/resources/jasperTemplates/requisition.jrxml
+++ b/src/main/resources/jasperTemplates/requisition.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.5.final using JasperReports Library version 6.20.5-3efcf2e67f959db3888d79f73dde2dbd7acb4f8e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisition" pageWidth="1165" pageHeight="595" orientation="Landscape" whenNoDataType="BlankPage" columnWidth="1000" leftMargin="0" rightMargin="0" topMargin="20" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Key" uuid="a0a4e861-0726-422f-b3d5-54b1aefe96ce">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisition" pageWidth="1165" pageHeight="595" orientation="Landscape" whenNoDataType="BlankPage" columnWidth="1000" leftMargin="0" rightMargin="0" topMargin="20" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Empty" uuid="a0a4e861-0726-422f-b3d5-54b1aefe96ce">
 	<property name="ireport.zoom" value="1.5"/>
 	<property name="ireport.x" value="9"/>
 	<property name="ireport.y" value="0"/>

--- a/src/main/resources/jasperTemplates/requisitionLines.jrxml
+++ b/src/main/resources/jasperTemplates/requisitionLines.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.5.final using JasperReports Library version 6.20.5-3efcf2e67f959db3888d79f73dde2dbd7acb4f8e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisitionLines" pageWidth="1160" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="960" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Empty" uuid="8eeca41d-cefe-475b-b89b-f898f69a4087">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisitionLines" pageWidth="1160" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="960" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Null" uuid="8eeca41d-cefe-475b-b89b-f898f69a4087">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -14,43 +14,45 @@
 	<import value="org.springframework.context.i18n.*"/>
 	<import value="java.util.*"/>
 	<import value="java.text.DecimalFormat"/>
-	<import value="org.openlmis.requisition.dto.*"/>
 	<import value="java.text.NumberFormat"/>
-	<parameter name="template" class="org.openlmis.requisition.domain.RequisitionTemplate" isForPrompting="false">
-		<property name="displayName" value="template"/>
+	<parameter name="columnLabels" class="java.util.Map" isForPrompting="false">
+		<property name="displayName" value="columnLabels"/>
+	</parameter>
+	<parameter name="columnLabelKeys" class="java.util.Map" isForPrompting="false">
+		<property name="displayName" value="columnLabelKeys"/>
 	</parameter>
 	<parameter name="title" class="java.lang.String" isForPrompting="false">
 		<property name="displayName" value="title"/>
 	</parameter>
-	<parameter name="requisitionStatus" class="org.openlmis.requisition.domain.requisition.RequisitionStatus" isForPrompting="false"/>
-	<parameter name="programId" class="java.util.UUID"/>
-	<parameter name="dateFormat" class="java.lang.String" isForPrompting="false"/>
+	<parameter name="requisitionAuthorized" class="java.lang.Boolean" isForPrompting="false"/>
 	<parameter name="decimalFormat" class="java.text.DecimalFormat" isForPrompting="false"/>
-	<parameter name="currencyDecimalFormat" class="java.text.NumberFormat" isForPrompting="false"/>
 	<parameter name="showInDoses" class="java.lang.Boolean"/>
 	<field name="adjustedConsumption" class="java.lang.Integer"/>
 	<field name="averageConsumption" class="java.lang.Integer"/>
 	<field name="calculatedOrderQuantity" class="java.lang.Integer"/>
 	<field name="numberOfNewPatientsAdded" class="java.lang.Integer"/>
-	<field name="orderable" class="org.openlmis.requisition.dto.OrderableDto"/>
+	<field name="productCode" class="java.lang.String"/>
+	<field name="fullProductName" class="java.lang.String"/>
+	<field name="dispensableDisplayUnit" class="java.lang.String"/>
+	<field name="categoryDisplayName" class="java.lang.String"/>
+	<field name="netContent" class="java.lang.Number"/>
 	<field name="beginningBalance" class="java.lang.Integer"/>
 	<field name="stockAdjustments" class="java.util.List"/>
 	<field name="totalLossesAndAdjustments" class="java.lang.Integer"/>
 	<field name="totalStockoutDays" class="java.lang.Integer"/>
-	<field name="packsToShip" class="java.lang.Long"/>
+	<field name="packsToShip" class="java.lang.Number"/>
 	<field name="approvedQuantity" class="java.lang.Integer"/>
 	<field name="skipped" class="java.lang.Boolean"/>
 	<field name="totalReceivedQuantity" class="java.lang.Integer"/>
 	<field name="total" class="java.lang.Integer"/>
 	<field name="totalConsumedQuantity" class="java.lang.Integer"/>
-	<field name="pricePerPack" class="org.joda.money.Money"/>
+	<field name="pricePerPack" class="java.lang.String"/>
 	<field name="requestedQuantity" class="java.lang.Integer"/>
 	<field name="requestedQuantityExplanation" class="java.lang.String"/>
 	<field name="stockOnHand" class="java.lang.Integer"/>
 	<field name="id" class="java.util.UUID"/>
-	<field name="class" class="java.lang.Class"/>
 	<field name="remarks" class="java.lang.String"/>
-	<field name="totalCost" class="org.joda.money.Money"/>
+	<field name="totalCost" class="java.lang.String"/>
 	<field name="maximumStockQuantity" class="java.lang.Integer"/>
 	<field name="calculatedOrderQuantityIsa" class="java.lang.Integer"/>
 	<field name="additionalQuantityRequired" class="java.lang.Integer"/>
@@ -62,11 +64,11 @@
 	<field name="convertedQuantityToIssue" class="java.lang.Integer"/>
 	<field name="dosesPerPatient" class="java.lang.Integer"/>
 	<variable name="netContent" class="java.lang.Long">
-		<variableExpression><![CDATA[$F{orderable}.getNetContent()]]></variableExpression>
+		<variableExpression><![CDATA[$F{netContent} == null ? null : Long.valueOf($F{netContent}.longValue())]]></variableExpression>
 		<initialValueExpression><![CDATA[1]]></initialValueExpression>
 	</variable>
 	<group name="OrderableDisplayCategory">
-		<groupExpression><![CDATA[$F{orderable}.getProgramOrderable($P{programId}).getOrderableCategoryDisplayName()]]></groupExpression>
+		<groupExpression><![CDATA[$F{categoryDisplayName}]]></groupExpression>
 		<groupHeader>
 			<band height="10">
 				<rectangle>
@@ -76,7 +78,7 @@
 						<property name="com.jaspersoft.studio.unit.width" value="px"/>
 					</reportElement>
 				</rectangle>
-				<textField>
+				<textField isBlankWhenNull="true">
 					<reportElement x="9" y="0" width="1142" height="10" uuid="29f84432-f48e-467d-b3fb-fc018b725111">
 						<property name="com.jaspersoft.studio.unit.height" value="pixel"/>
 						<property name="com.jaspersoft.studio.unit.y" value="px"/>
@@ -86,7 +88,7 @@
 					<textElement textAlignment="Center">
 						<font size="8"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{orderable}.getProgramOrderable($P{programId}).getOrderableCategoryDisplayName()]]></textFieldExpression>
+					<textFieldExpression><![CDATA[$F{categoryDisplayName}]]></textFieldExpression>
 				</textField>
 			</band>
 		</groupHeader>
@@ -126,7 +128,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.fullProductName").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("orderable.fullProductName") != null && str((String) $P{columnLabelKeys}.get("orderable.fullProductName")) != null ? str((String) $P{columnLabelKeys}.get("orderable.fullProductName")) : (String) $P{columnLabels}.get("orderable.fullProductName")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="orderable.productCode" mode="Opaque" x="9" y="0" width="31" height="35" backcolor="#CCCCCC" uuid="aa050bad-b263-43fa-8d5e-9c9b506f2260">
@@ -144,7 +146,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.productCode").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("orderable.productCode") != null && str((String) $P{columnLabelKeys}.get("orderable.productCode")) != null ? str((String) $P{columnLabelKeys}.get("orderable.productCode")) : (String) $P{columnLabels}.get("orderable.productCode")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="beginningBalance" mode="Opaque" x="140" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="ba36ed17-bea4-4f3c-9a77-1e1adb90aedb">
@@ -160,7 +162,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("beginningBalance").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("beginningBalance") != null && str((String) $P{columnLabelKeys}.get("beginningBalance")) != null ? str((String) $P{columnLabelKeys}.get("beginningBalance")) : (String) $P{columnLabels}.get("beginningBalance")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalReceivedQuantity" mode="Opaque" x="172" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="925448c8-3d6b-4b79-93b2-38b441c379fa">
@@ -177,7 +179,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalReceivedQuantity").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalReceivedQuantity") != null && str((String) $P{columnLabelKeys}.get("totalReceivedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("totalReceivedQuantity")) : (String) $P{columnLabels}.get("totalReceivedQuantity")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalConsumedQuantity" mode="Opaque" x="204" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="7b859dc6-720f-43e0-9092-886ad01a9d50">
@@ -194,7 +196,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalConsumedQuantity").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalConsumedQuantity") != null && str((String) $P{columnLabelKeys}.get("totalConsumedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("totalConsumedQuantity")) : (String) $P{columnLabels}.get("totalConsumedQuantity")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalLossesAndAdjustments" mode="Opaque" x="236" y="0" width="38" height="35" backcolor="#CCCCCC" uuid="dc09a9f2-acf7-4dab-84ef-a500845dde6d">
@@ -211,7 +213,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalLossesAndAdjustments").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalLossesAndAdjustments") != null && str((String) $P{columnLabelKeys}.get("totalLossesAndAdjustments")) != null ? str((String) $P{columnLabelKeys}.get("totalLossesAndAdjustments")) : (String) $P{columnLabels}.get("totalLossesAndAdjustments")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="stockOnHand" mode="Opaque" x="274" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="ff7df6d1-53e7-49c8-a94a-0e026f345a39">
@@ -227,7 +229,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("stockOnHand").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("stockOnHand") != null && str((String) $P{columnLabelKeys}.get("stockOnHand")) != null ? str((String) $P{columnLabelKeys}.get("stockOnHand")) : (String) $P{columnLabels}.get("stockOnHand")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="requestedQuantity" mode="Opaque" x="306" y="0" width="34" height="35" backcolor="#CCCCCC" uuid="39121943-899a-42d8-93c2-974a7b408fb0">
@@ -244,7 +246,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("requestedQuantity").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("requestedQuantity") != null && str((String) $P{columnLabelKeys}.get("requestedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("requestedQuantity")) : (String) $P{columnLabels}.get("requestedQuantity")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="requestedQuantityExplanation" mode="Opaque" x="340" y="0" width="70" height="35" backcolor="#CCCCCC" uuid="344870d7-8dd4-49a3-b597-d4b615a20eee">
@@ -261,13 +263,13 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("requestedQuantityExplanation").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("requestedQuantityExplanation") != null && str((String) $P{columnLabelKeys}.get("requestedQuantityExplanation")) != null ? str((String) $P{columnLabelKeys}.get("requestedQuantityExplanation")) : (String) $P{columnLabels}.get("requestedQuantityExplanation")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="approvedQuantity" mode="Opaque" x="410" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="5ca60a9a-32ae-47e4-b72f-6be575361d5c">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[$P{requisitionStatus}.isAuthorized()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{requisitionAuthorized}]]></printWhenExpression>
 				</reportElement>
 				<box padding="2">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
@@ -278,13 +280,13 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("approvedQuantity").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("approvedQuantity") != null && str((String) $P{columnLabelKeys}.get("approvedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("approvedQuantity")) : (String) $P{columnLabels}.get("approvedQuantity")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="remarks" mode="Opaque" x="442" y="0" width="68" height="35" backcolor="#CCCCCC" uuid="037372e2-a4c6-4675-9eb1-cd3d955c2961">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[$P{requisitionStatus}.isAuthorized()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{requisitionAuthorized}]]></printWhenExpression>
 				</reportElement>
 				<box padding="2">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
@@ -295,7 +297,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("remarks").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("remarks") != null && str((String) $P{columnLabelKeys}.get("remarks")) != null ? str((String) $P{columnLabelKeys}.get("remarks")) : (String) $P{columnLabels}.get("remarks")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalStockoutDays" mode="Opaque" x="510" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="38ca3046-107c-49cf-ab32-b6b2a0ad659c">
@@ -311,7 +313,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalStockoutDays").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalStockoutDays") != null && str((String) $P{columnLabelKeys}.get("totalStockoutDays")) != null ? str((String) $P{columnLabelKeys}.get("totalStockoutDays")) : (String) $P{columnLabels}.get("totalStockoutDays")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="total" mode="Opaque" x="540" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="be01de2b-4274-413e-bb50-9463735e2c87">
@@ -327,7 +329,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("total").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("total") != null && str((String) $P{columnLabelKeys}.get("total")) != null ? str((String) $P{columnLabelKeys}.get("total")) : (String) $P{columnLabels}.get("total")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="orderable.dispensable.displayUnit" mode="Opaque" x="100" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="88b07504-aa0a-4fb4-a4fc-71b3d8b091ef">
@@ -343,7 +345,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.dispensable.displayUnit").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("orderable.dispensable.displayUnit") != null && str((String) $P{columnLabelKeys}.get("orderable.dispensable.displayUnit")) != null ? str((String) $P{columnLabelKeys}.get("orderable.dispensable.displayUnit")) : (String) $P{columnLabels}.get("orderable.dispensable.displayUnit")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="packsToShip" mode="Opaque" x="570" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="b7f0ed2c-71bf-47b6-a4cc-f74ab3a5688d">
@@ -359,7 +361,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("packsToShip").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("packsToShip") != null && str((String) $P{columnLabelKeys}.get("packsToShip")) != null ? str((String) $P{columnLabelKeys}.get("packsToShip")) : (String) $P{columnLabels}.get("packsToShip")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="pricePerPack" mode="Opaque" x="600" y="0" width="45" height="35" backcolor="#CCCCCC" uuid="74eb88e0-bdb7-49df-8556-5ee3e4b78647">
@@ -376,7 +378,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("pricePerPack").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("pricePerPack") != null && str((String) $P{columnLabelKeys}.get("pricePerPack")) != null ? str((String) $P{columnLabelKeys}.get("pricePerPack")) : (String) $P{columnLabels}.get("pricePerPack")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="numberOfNewPatientsAdded" mode="Opaque" x="645" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="326f1d21-fe28-4c47-a971-747e3b295acc">
@@ -392,7 +394,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("numberOfNewPatientsAdded").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("numberOfNewPatientsAdded") != null && str((String) $P{columnLabelKeys}.get("numberOfNewPatientsAdded")) != null ? str((String) $P{columnLabelKeys}.get("numberOfNewPatientsAdded")) : (String) $P{columnLabels}.get("numberOfNewPatientsAdded")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="maximumStockQuantity" mode="Opaque" x="675" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="c35d9bde-2a31-11e9-b210-d663bd873d93">
@@ -408,7 +410,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("maximumStockQuantity").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("maximumStockQuantity") != null && str((String) $P{columnLabelKeys}.get("maximumStockQuantity")) != null ? str((String) $P{columnLabelKeys}.get("maximumStockQuantity")) : (String) $P{columnLabels}.get("maximumStockQuantity")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalCost" mode="Opaque" x="705" y="0" width="45" height="35" backcolor="#CCCCCC" uuid="4b173290-a1ae-4c11-bc47-dfb8fb4e1710">
@@ -424,7 +426,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalCost").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalCost") != null && str((String) $P{columnLabelKeys}.get("totalCost")) != null ? str((String) $P{columnLabelKeys}.get("totalCost")) : (String) $P{columnLabels}.get("totalCost")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="adjustedConsumption" mode="Opaque" x="750" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="856d2220-e43a-4111-8ec0-b630b1bdc0bb">
@@ -440,7 +442,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("adjustedConsumption").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("adjustedConsumption") != null && str((String) $P{columnLabelKeys}.get("adjustedConsumption")) != null ? str((String) $P{columnLabelKeys}.get("adjustedConsumption")) : (String) $P{columnLabels}.get("adjustedConsumption")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="averageConsumption" mode="Opaque" x="790" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="86c38ec7-30e4-4a5d-98fc-a62d1149c2eb">
@@ -456,7 +458,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("averageConsumption").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("averageConsumption") != null && str((String) $P{columnLabelKeys}.get("averageConsumption")) != null ? str((String) $P{columnLabelKeys}.get("averageConsumption")) : (String) $P{columnLabels}.get("averageConsumption")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="calculatedOrderQuantity" mode="Opaque" x="830" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="2eceb46c-22e9-4385-8c3d-645efa2c1d13">
@@ -473,7 +475,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("calculatedOrderQuantity").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("calculatedOrderQuantity") != null && str((String) $P{columnLabelKeys}.get("calculatedOrderQuantity")) != null ? str((String) $P{columnLabelKeys}.get("calculatedOrderQuantity")) : (String) $P{columnLabels}.get("calculatedOrderQuantity")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="calculatedOrderQuantityIsa" mode="Opaque" x="860" y="0" width="34" height="35" backcolor="#CCCCCC" uuid="4f62f690-2c4b-11e9-b210-d663bd873d93">
@@ -490,7 +492,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("calculatedOrderQuantityIsa").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("calculatedOrderQuantityIsa") != null && str((String) $P{columnLabelKeys}.get("calculatedOrderQuantityIsa")) != null ? str((String) $P{columnLabelKeys}.get("calculatedOrderQuantityIsa")) : (String) $P{columnLabels}.get("calculatedOrderQuantityIsa")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="additionalQuantityRequired" mode="Opaque" x="894" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="1163d192-510e-4b7b-9b8b-3563c779cdc3">
@@ -507,7 +509,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("additionalQuantityRequired").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("additionalQuantityRequired") != null && str((String) $P{columnLabelKeys}.get("additionalQuantityRequired")) != null ? str((String) $P{columnLabelKeys}.get("additionalQuantityRequired")) : (String) $P{columnLabels}.get("additionalQuantityRequired")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="idealStockAmount" mode="Opaque" x="923" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="633a1c97-1c7e-44bd-a603-8df8edbba734">
@@ -524,7 +526,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("idealStockAmount").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("idealStockAmount") != null && str((String) $P{columnLabelKeys}.get("idealStockAmount")) != null ? str((String) $P{columnLabelKeys}.get("idealStockAmount")) : (String) $P{columnLabels}.get("idealStockAmount")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="numberOfPatientsOnTreatmentNextMonth" mode="Opaque" x="952" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="e5d32d95-a523-48e4-845f-b9bf0b7b1ae8">
@@ -541,7 +543,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("numberOfPatientsOnTreatmentNextMonth").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("numberOfPatientsOnTreatmentNextMonth") != null && str((String) $P{columnLabelKeys}.get("numberOfPatientsOnTreatmentNextMonth")) != null ? str((String) $P{columnLabelKeys}.get("numberOfPatientsOnTreatmentNextMonth")) : (String) $P{columnLabels}.get("numberOfPatientsOnTreatmentNextMonth")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="convertedQuantityToIssue" mode="Opaque" x="1068" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="9eee353a-ae4e-4080-b94a-d1e3f6d5887c">
@@ -559,7 +561,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("convertedQuantityToIssue").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("convertedQuantityToIssue") != null && str((String) $P{columnLabelKeys}.get("convertedQuantityToIssue")) != null ? str((String) $P{columnLabelKeys}.get("convertedQuantityToIssue")) : (String) $P{columnLabels}.get("convertedQuantityToIssue")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalRequirement" mode="Opaque" x="981" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="8bbe42c5-8a2f-4ad9-bc38-721aec76bded">
@@ -577,7 +579,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalRequirement").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalRequirement") != null && str((String) $P{columnLabelKeys}.get("totalRequirement")) != null ? str((String) $P{columnLabelKeys}.get("totalRequirement")) : (String) $P{columnLabels}.get("totalRequirement")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalQuantityNeededByHf" mode="Opaque" x="1010" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="7bbb1e14-0c77-4a41-b46d-d79c1db1475b">
@@ -595,7 +597,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalQuantityNeededByHf").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalQuantityNeededByHf") != null && str((String) $P{columnLabelKeys}.get("totalQuantityNeededByHf")) != null ? str((String) $P{columnLabelKeys}.get("totalQuantityNeededByHf")) : (String) $P{columnLabels}.get("totalQuantityNeededByHf")]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Group" evaluationGroup="OrderableDisplayCategory">
 				<reportElement key="quantityToIssue" mode="Opaque" x="1039" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="a41526fc-1510-4e91-854e-5ddbde27ab6e">
@@ -612,7 +614,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("quantityToIssue").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("quantityToIssue") != null && str((String) $P{columnLabelKeys}.get("quantityToIssue")) != null ? str((String) $P{columnLabelKeys}.get("quantityToIssue")) : (String) $P{columnLabels}.get("quantityToIssue")]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="dosesPerPatient" mode="Opaque" x="1108" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="16e4af5c-05d3-4dfb-8c3b-afd3a5bf7d2a">
@@ -630,7 +632,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("dosesPerPatient").getLabel()]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("dosesPerPatient") != null && str((String) $P{columnLabelKeys}.get("dosesPerPatient")) != null ? str((String) $P{columnLabelKeys}.get("dosesPerPatient")) : (String) $P{columnLabels}.get("dosesPerPatient")]]></textFieldExpression>
 			</textField>
 		</band>
 	</columnHeader>
@@ -661,7 +663,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.fullProductName").getIsDisplayed() ? $F{orderable}.getFullProductName() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{fullProductName}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="orderable.productCode" x="9" y="0" width="31" height="25" uuid="364650f2-c5ab-49b6-b74a-89aa733eeda5">
@@ -678,7 +680,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.productCode").getIsDisplayed() ? $F{orderable}.getProductCode() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{productCode}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="beginningBalance" x="140" y="0" width="32" height="25" uuid="a7672f9a-30bd-4bf9-96af-324baa7e2280">
@@ -694,7 +696,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("beginningBalance").getIsDisplayed() && $F{beginningBalance} != null ?
+                <textFieldExpression><![CDATA[$F{beginningBalance} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{beginningBalance}).toString()
@@ -719,7 +721,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalReceivedQuantity").getIsDisplayed() && $F{totalReceivedQuantity} != null ?
+                <textFieldExpression><![CDATA[$F{totalReceivedQuantity} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{totalReceivedQuantity}).toString()
@@ -744,7 +746,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalConsumedQuantity").getIsDisplayed() && $F{totalConsumedQuantity} != null ?
+                <textFieldExpression><![CDATA[$F{totalConsumedQuantity} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{totalConsumedQuantity}).toString()
@@ -769,7 +771,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalLossesAndAdjustments").getIsDisplayed() && $F{totalLossesAndAdjustments} != null ?
+                <textFieldExpression><![CDATA[$F{totalLossesAndAdjustments} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{totalLossesAndAdjustments}).toString()
@@ -794,7 +796,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("stockOnHand").getIsDisplayed() && $F{stockOnHand} != null ?
+				<textFieldExpression><![CDATA[$F{stockOnHand} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{stockOnHand}).toString()
@@ -819,13 +821,13 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("requestedQuantityExplanation").getIsDisplayed() ? $F{requestedQuantityExplanation} : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{requestedQuantityExplanation}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="approvedQuantity" x="410" y="0" width="32" height="25" uuid="123d5789-9a0e-493b-9dcb-8fd89100a599">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[$P{requisitionStatus}.isAuthorized()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{requisitionAuthorized}]]></printWhenExpression>
 				</reportElement>
 				<box padding="2">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
@@ -836,7 +838,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("approvedQuantity").getIsDisplayed() && $F{approvedQuantity} != null ?
+                <textFieldExpression><![CDATA[$F{approvedQuantity} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{approvedQuantity}).toString()
@@ -862,7 +864,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalStockoutDays").getIsDisplayed() && $F{totalStockoutDays} != null ? $P{decimalFormat}.format($F{totalStockoutDays}).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{totalStockoutDays} != null ? $P{decimalFormat}.format($F{totalStockoutDays}).toString() : null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="total" x="540" y="0" width="30" height="25" uuid="2aef1b8a-a7cb-4972-9506-22d1ccc2a945">
@@ -879,7 +881,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("total").getIsDisplayed() && $F{total} != null ? $P{decimalFormat}.format($F{total}).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{total} != null ? $P{decimalFormat}.format($F{total}).toString() : null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="orderable.dispensable.displayUnit" x="100" y="0" width="40" height="25" uuid="0e217f2e-f7ca-4c05-b9d2-f13ec6cf38db">
@@ -896,7 +898,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("orderable.dispensable.displayUnit").getIsDisplayed() ? $F{orderable}.getDispensable().getDisplayUnit() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{dispensableDisplayUnit}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="packsToShip" x="570" y="0" width="30" height="25" uuid="97268fb4-abce-44f3-9162-3376a5e64000">
@@ -913,7 +915,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("packsToShip").getIsDisplayed() && $F{packsToShip} != null ? $P{decimalFormat}.format($F{packsToShip}).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{packsToShip} != null ? $P{decimalFormat}.format($F{packsToShip}).toString() : null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="pricePerPack" x="600" y="0" width="45" height="25" uuid="8a78859d-6649-4ac8-9538-48ce2f44ad67">
@@ -930,7 +932,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("pricePerPack").getIsDisplayed() ? $P{currencyDecimalFormat}.format(new BigDecimal($F{pricePerPack}.toString().replaceAll("[^0-9?!\\.]+", ""))).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{pricePerPack}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="numberOfNewPatientsAdded" x="645" y="0" width="30" height="25" uuid="fea4bade-1ea2-4739-83fa-93be949392a2">
@@ -947,7 +949,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("numberOfNewPatientsAdded").getIsDisplayed() && $F{numberOfNewPatientsAdded} != null ? $P{decimalFormat}.format($F{numberOfNewPatientsAdded}).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{numberOfNewPatientsAdded} != null ? $P{decimalFormat}.format($F{numberOfNewPatientsAdded}).toString() : null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="maximumStockQuantity" x="675" y="0" width="30" height="25" uuid="d8c3a7c4-5705-437e-ad7a-a1f90d2bbfce">
@@ -964,7 +966,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("maximumStockQuantity").getIsDisplayed() && $F{maximumStockQuantity} != null ?
+                <textFieldExpression><![CDATA[$F{maximumStockQuantity} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{maximumStockQuantity}).toString()
@@ -989,7 +991,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalCost").getIsDisplayed() ? $P{currencyDecimalFormat}.format(new BigDecimal($F{totalCost}.toString().replaceAll("[^0-9?!\\.]+", ""))).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{totalCost}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="averageConsumption" x="790" y="0" width="40" height="25" uuid="415e8964-fd1f-4c09-a7fe-7b34036549d9">
@@ -1006,7 +1008,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("averageConsumption").getIsDisplayed() && $F{averageConsumption} != null ?
+                <textFieldExpression><![CDATA[$F{averageConsumption} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{averageConsumption}).toString()
@@ -1021,7 +1023,7 @@
 				<reportElement key="remarks" x="442" y="0" width="68" height="25" uuid="b995a245-0802-4412-b304-d4dc8741b567">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
-					<printWhenExpression><![CDATA[$P{requisitionStatus}.isAuthorized()]]></printWhenExpression>
+					<printWhenExpression><![CDATA[$P{requisitionAuthorized}]]></printWhenExpression>
 				</reportElement>
 				<box padding="2">
 					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
@@ -1032,7 +1034,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[($P{template}.viewColumns().get("remarks").getIsDisplayed() && $P{requisitionStatus}.isAuthorized()) ? $F{remarks} : ""]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{remarks}]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="adjustedConsumption" x="750" y="0" width="40" height="25" uuid="2a43948d-6150-4c4f-ba77-2ad782def76b">
@@ -1049,7 +1051,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("adjustedConsumption").getIsDisplayed() && $F{adjustedConsumption} != null ?
+                <textFieldExpression><![CDATA[$F{adjustedConsumption} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{adjustedConsumption}).toString()
@@ -1075,7 +1077,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("requestedQuantity").getIsDisplayed() && $F{requestedQuantity} != null ?
+                <textFieldExpression><![CDATA[$F{requestedQuantity} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{requestedQuantity}).toString()
@@ -1101,7 +1103,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("calculatedOrderQuantity").getIsDisplayed() && $F{calculatedOrderQuantity} != null ?
+                <textFieldExpression><![CDATA[$F{calculatedOrderQuantity} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{calculatedOrderQuantity}).toString()
@@ -1127,7 +1129,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("calculatedOrderQuantityIsa").getIsDisplayed() && $F{calculatedOrderQuantityIsa} != null ? $P{decimalFormat}.format($F{calculatedOrderQuantityIsa}).toString() : null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{calculatedOrderQuantityIsa} != null ? $P{decimalFormat}.format($F{calculatedOrderQuantityIsa}).toString() : null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="additionalQuantityRequired" x="894" y="0" width="29" height="25" uuid="3125c641-4c2c-4ecf-9e4e-399eb11f7404">
@@ -1143,7 +1145,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("additionalQuantityRequired").getIsDisplayed() && $F{additionalQuantityRequired} != null ? $P{decimalFormat}.format($F{additionalQuantityRequired}).toString() : 0.0]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{additionalQuantityRequired} != null ? $P{decimalFormat}.format($F{additionalQuantityRequired}).toString() : 0.0]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="idealStockAmount" x="923" y="0" width="29" height="25" uuid="1440d337-ee37-48ff-9dc9-a4ce4360fc13">
@@ -1159,7 +1161,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("idealStockAmount").getIsDisplayed() && $F{idealStockAmount} != null ? $P{decimalFormat}.format($F{idealStockAmount}).toString() :  null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{idealStockAmount} != null ? $P{decimalFormat}.format($F{idealStockAmount}).toString() :  null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="numberOfPatientsOnTreatmentNextMonth" x="952" y="0" width="29" height="25" uuid="afc498ca-274f-46e0-8b4c-efe95ae18e9a">
@@ -1175,7 +1177,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("numberOfPatientsOnTreatmentNextMonth").getIsDisplayed() && $F{numberOfPatientsOnTreatmentNextMonth} != null ? $P{decimalFormat}.format($F{numberOfPatientsOnTreatmentNextMonth}).toString() :  null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{numberOfPatientsOnTreatmentNextMonth} != null ? $P{decimalFormat}.format($F{numberOfPatientsOnTreatmentNextMonth}).toString() :  null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="totalRequirement" x="981" y="0" width="29" height="25" uuid="f7eb6312-f71b-43fa-bca9-71e7d549bf6b">
@@ -1192,7 +1194,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalRequirement").getIsDisplayed() && $F{totalRequirement} != null ?
+                <textFieldExpression><![CDATA[$F{totalRequirement} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{totalRequirement}).toString()
@@ -1218,7 +1220,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("totalQuantityNeededByHf").getIsDisplayed() && $F{totalQuantityNeededByHf} != null ?
+                <textFieldExpression><![CDATA[$F{totalQuantityNeededByHf} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{totalQuantityNeededByHf}).toString()
@@ -1244,7 +1246,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-                <textFieldExpression><![CDATA[$P{template}.viewColumns().get("quantityToIssue").getIsDisplayed() && $F{quantityToIssue} != null ?
+                <textFieldExpression><![CDATA[$F{quantityToIssue} != null ?
 				(
 	                $P{showInDoses}
                           ? $P{decimalFormat}.format($F{quantityToIssue}).toString()
@@ -1271,7 +1273,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("convertedQuantityToIssue").getIsDisplayed() && $F{convertedQuantityToIssue} != null ? $P{decimalFormat}.format($F{convertedQuantityToIssue}).toString() :  null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{convertedQuantityToIssue} != null ? $P{decimalFormat}.format($F{convertedQuantityToIssue}).toString() :  null]]></textFieldExpression>
 			</textField>
 			<textField isBlankWhenNull="true">
 				<reportElement key="dosesPerPatient" x="1108" y="0" width="40" height="25" uuid="8460e296-4260-43c2-9a95-8dd3ed315cbc">
@@ -1289,7 +1291,7 @@
 				<textElement textAlignment="Left" verticalAlignment="Top">
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{template}.viewColumns().get("dosesPerPatient").getIsDisplayed() && $F{dosesPerPatient} != null ? $P{decimalFormat}.format($F{dosesPerPatient}).toString() :  null]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{dosesPerPatient} != null ? $P{decimalFormat}.format($F{dosesPerPatient}).toString() :  null]]></textFieldExpression>
 			</textField>
 		</band>
 	</detail>

--- a/src/main/resources/jasperTemplates/requisitionLines.jrxml
+++ b/src/main/resources/jasperTemplates/requisitionLines.jrxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Jaspersoft Studio version 6.20.5.final using JasperReports Library version 6.20.5-3efcf2e67f959db3888d79f73dde2dbd7acb4f8e  -->
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisitionLines" pageWidth="1160" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="960" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Null" uuid="8eeca41d-cefe-475b-b89b-f898f69a4087">
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="requisitionLines" pageWidth="1160" pageHeight="595" orientation="Landscape" whenNoDataType="AllSectionsNoDetail" columnWidth="960" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" isFloatColumnFooter="true" whenResourceMissingType="Empty" uuid="8eeca41d-cefe-475b-b89b-f898f69a4087">
 	<property name="com.jaspersoft.studio.unit." value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
 	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
@@ -15,12 +15,6 @@
 	<import value="java.util.*"/>
 	<import value="java.text.DecimalFormat"/>
 	<import value="java.text.NumberFormat"/>
-	<parameter name="columnLabels" class="java.util.Map" isForPrompting="false">
-		<property name="displayName" value="columnLabels"/>
-	</parameter>
-	<parameter name="columnLabelKeys" class="java.util.Map" isForPrompting="false">
-		<property name="displayName" value="columnLabelKeys"/>
-	</parameter>
 	<parameter name="title" class="java.lang.String" isForPrompting="false">
 		<property name="displayName" value="title"/>
 	</parameter>
@@ -128,7 +122,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("orderable.fullProductName") != null && str((String) $P{columnLabelKeys}.get("orderable.fullProductName")) != null ? str((String) $P{columnLabelKeys}.get("orderable.fullProductName")) : (String) $P{columnLabels}.get("orderable.fullProductName")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.orderable.fullProductName}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="orderable.productCode" mode="Opaque" x="9" y="0" width="31" height="35" backcolor="#CCCCCC" uuid="aa050bad-b263-43fa-8d5e-9c9b506f2260">
@@ -146,7 +140,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("orderable.productCode") != null && str((String) $P{columnLabelKeys}.get("orderable.productCode")) != null ? str((String) $P{columnLabelKeys}.get("orderable.productCode")) : (String) $P{columnLabels}.get("orderable.productCode")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.orderable.productCode}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="beginningBalance" mode="Opaque" x="140" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="ba36ed17-bea4-4f3c-9a77-1e1adb90aedb">
@@ -162,7 +156,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("beginningBalance") != null && str((String) $P{columnLabelKeys}.get("beginningBalance")) != null ? str((String) $P{columnLabelKeys}.get("beginningBalance")) : (String) $P{columnLabels}.get("beginningBalance")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.beginningBalance}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalReceivedQuantity" mode="Opaque" x="172" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="925448c8-3d6b-4b79-93b2-38b441c379fa">
@@ -179,7 +173,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalReceivedQuantity") != null && str((String) $P{columnLabelKeys}.get("totalReceivedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("totalReceivedQuantity")) : (String) $P{columnLabels}.get("totalReceivedQuantity")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalReceivedQuantity}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalConsumedQuantity" mode="Opaque" x="204" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="7b859dc6-720f-43e0-9092-886ad01a9d50">
@@ -196,7 +190,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalConsumedQuantity") != null && str((String) $P{columnLabelKeys}.get("totalConsumedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("totalConsumedQuantity")) : (String) $P{columnLabels}.get("totalConsumedQuantity")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalConsumedQuantity}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalLossesAndAdjustments" mode="Opaque" x="236" y="0" width="38" height="35" backcolor="#CCCCCC" uuid="dc09a9f2-acf7-4dab-84ef-a500845dde6d">
@@ -213,7 +207,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalLossesAndAdjustments") != null && str((String) $P{columnLabelKeys}.get("totalLossesAndAdjustments")) != null ? str((String) $P{columnLabelKeys}.get("totalLossesAndAdjustments")) : (String) $P{columnLabels}.get("totalLossesAndAdjustments")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalLossesAndAdjustments}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="stockOnHand" mode="Opaque" x="274" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="ff7df6d1-53e7-49c8-a94a-0e026f345a39">
@@ -229,7 +223,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("stockOnHand") != null && str((String) $P{columnLabelKeys}.get("stockOnHand")) != null ? str((String) $P{columnLabelKeys}.get("stockOnHand")) : (String) $P{columnLabels}.get("stockOnHand")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.stockOnHand}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="requestedQuantity" mode="Opaque" x="306" y="0" width="34" height="35" backcolor="#CCCCCC" uuid="39121943-899a-42d8-93c2-974a7b408fb0">
@@ -246,7 +240,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("requestedQuantity") != null && str((String) $P{columnLabelKeys}.get("requestedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("requestedQuantity")) : (String) $P{columnLabels}.get("requestedQuantity")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.requestedQuantity}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="requestedQuantityExplanation" mode="Opaque" x="340" y="0" width="70" height="35" backcolor="#CCCCCC" uuid="344870d7-8dd4-49a3-b597-d4b615a20eee">
@@ -263,7 +257,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("requestedQuantityExplanation") != null && str((String) $P{columnLabelKeys}.get("requestedQuantityExplanation")) != null ? str((String) $P{columnLabelKeys}.get("requestedQuantityExplanation")) : (String) $P{columnLabels}.get("requestedQuantityExplanation")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.requestedQuantityExplanation}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="approvedQuantity" mode="Opaque" x="410" y="0" width="32" height="35" backcolor="#CCCCCC" uuid="5ca60a9a-32ae-47e4-b72f-6be575361d5c">
@@ -280,7 +274,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("approvedQuantity") != null && str((String) $P{columnLabelKeys}.get("approvedQuantity")) != null ? str((String) $P{columnLabelKeys}.get("approvedQuantity")) : (String) $P{columnLabels}.get("approvedQuantity")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.approvedQuantity}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="remarks" mode="Opaque" x="442" y="0" width="68" height="35" backcolor="#CCCCCC" uuid="037372e2-a4c6-4675-9eb1-cd3d955c2961">
@@ -297,7 +291,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("remarks") != null && str((String) $P{columnLabelKeys}.get("remarks")) != null ? str((String) $P{columnLabelKeys}.get("remarks")) : (String) $P{columnLabels}.get("remarks")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.remarks}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalStockoutDays" mode="Opaque" x="510" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="38ca3046-107c-49cf-ab32-b6b2a0ad659c">
@@ -313,7 +307,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalStockoutDays") != null && str((String) $P{columnLabelKeys}.get("totalStockoutDays")) != null ? str((String) $P{columnLabelKeys}.get("totalStockoutDays")) : (String) $P{columnLabels}.get("totalStockoutDays")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalStockoutDays}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="total" mode="Opaque" x="540" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="be01de2b-4274-413e-bb50-9463735e2c87">
@@ -329,7 +323,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("total") != null && str((String) $P{columnLabelKeys}.get("total")) != null ? str((String) $P{columnLabelKeys}.get("total")) : (String) $P{columnLabels}.get("total")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.total}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="orderable.dispensable.displayUnit" mode="Opaque" x="100" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="88b07504-aa0a-4fb4-a4fc-71b3d8b091ef">
@@ -345,7 +339,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("orderable.dispensable.displayUnit") != null && str((String) $P{columnLabelKeys}.get("orderable.dispensable.displayUnit")) != null ? str((String) $P{columnLabelKeys}.get("orderable.dispensable.displayUnit")) : (String) $P{columnLabels}.get("orderable.dispensable.displayUnit")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.orderable.dispensable.displayUnit}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="packsToShip" mode="Opaque" x="570" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="b7f0ed2c-71bf-47b6-a4cc-f74ab3a5688d">
@@ -361,7 +355,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("packsToShip") != null && str((String) $P{columnLabelKeys}.get("packsToShip")) != null ? str((String) $P{columnLabelKeys}.get("packsToShip")) : (String) $P{columnLabels}.get("packsToShip")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.packsToShip}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="pricePerPack" mode="Opaque" x="600" y="0" width="45" height="35" backcolor="#CCCCCC" uuid="74eb88e0-bdb7-49df-8556-5ee3e4b78647">
@@ -378,7 +372,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("pricePerPack") != null && str((String) $P{columnLabelKeys}.get("pricePerPack")) != null ? str((String) $P{columnLabelKeys}.get("pricePerPack")) : (String) $P{columnLabels}.get("pricePerPack")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.pricePerPack}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="numberOfNewPatientsAdded" mode="Opaque" x="645" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="326f1d21-fe28-4c47-a971-747e3b295acc">
@@ -394,7 +388,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("numberOfNewPatientsAdded") != null && str((String) $P{columnLabelKeys}.get("numberOfNewPatientsAdded")) != null ? str((String) $P{columnLabelKeys}.get("numberOfNewPatientsAdded")) : (String) $P{columnLabels}.get("numberOfNewPatientsAdded")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.numberOfNewPatientsAdded}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="maximumStockQuantity" mode="Opaque" x="675" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="c35d9bde-2a31-11e9-b210-d663bd873d93">
@@ -410,7 +404,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("maximumStockQuantity") != null && str((String) $P{columnLabelKeys}.get("maximumStockQuantity")) != null ? str((String) $P{columnLabelKeys}.get("maximumStockQuantity")) : (String) $P{columnLabels}.get("maximumStockQuantity")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.maximumStockQuantity}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalCost" mode="Opaque" x="705" y="0" width="45" height="35" backcolor="#CCCCCC" uuid="4b173290-a1ae-4c11-bc47-dfb8fb4e1710">
@@ -426,7 +420,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalCost") != null && str((String) $P{columnLabelKeys}.get("totalCost")) != null ? str((String) $P{columnLabelKeys}.get("totalCost")) : (String) $P{columnLabels}.get("totalCost")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalCost}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="adjustedConsumption" mode="Opaque" x="750" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="856d2220-e43a-4111-8ec0-b630b1bdc0bb">
@@ -442,7 +436,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("adjustedConsumption") != null && str((String) $P{columnLabelKeys}.get("adjustedConsumption")) != null ? str((String) $P{columnLabelKeys}.get("adjustedConsumption")) : (String) $P{columnLabels}.get("adjustedConsumption")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.adjustedConsumption}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="averageConsumption" mode="Opaque" x="790" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="86c38ec7-30e4-4a5d-98fc-a62d1149c2eb">
@@ -458,7 +452,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("averageConsumption") != null && str((String) $P{columnLabelKeys}.get("averageConsumption")) != null ? str((String) $P{columnLabelKeys}.get("averageConsumption")) : (String) $P{columnLabels}.get("averageConsumption")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.averageConsumption}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="calculatedOrderQuantity" mode="Opaque" x="830" y="0" width="30" height="35" backcolor="#CCCCCC" uuid="2eceb46c-22e9-4385-8c3d-645efa2c1d13">
@@ -475,7 +469,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("calculatedOrderQuantity") != null && str((String) $P{columnLabelKeys}.get("calculatedOrderQuantity")) != null ? str((String) $P{columnLabelKeys}.get("calculatedOrderQuantity")) : (String) $P{columnLabels}.get("calculatedOrderQuantity")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.calculatedOrderQuantity}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="calculatedOrderQuantityIsa" mode="Opaque" x="860" y="0" width="34" height="35" backcolor="#CCCCCC" uuid="4f62f690-2c4b-11e9-b210-d663bd873d93">
@@ -492,7 +486,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("calculatedOrderQuantityIsa") != null && str((String) $P{columnLabelKeys}.get("calculatedOrderQuantityIsa")) != null ? str((String) $P{columnLabelKeys}.get("calculatedOrderQuantityIsa")) : (String) $P{columnLabels}.get("calculatedOrderQuantityIsa")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.calculatedOrderQuantityIsa}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="additionalQuantityRequired" mode="Opaque" x="894" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="1163d192-510e-4b7b-9b8b-3563c779cdc3">
@@ -509,7 +503,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("additionalQuantityRequired") != null && str((String) $P{columnLabelKeys}.get("additionalQuantityRequired")) != null ? str((String) $P{columnLabelKeys}.get("additionalQuantityRequired")) : (String) $P{columnLabels}.get("additionalQuantityRequired")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.additionalQuantityRequired}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="idealStockAmount" mode="Opaque" x="923" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="633a1c97-1c7e-44bd-a603-8df8edbba734">
@@ -526,7 +520,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("idealStockAmount") != null && str((String) $P{columnLabelKeys}.get("idealStockAmount")) != null ? str((String) $P{columnLabelKeys}.get("idealStockAmount")) : (String) $P{columnLabels}.get("idealStockAmount")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.idealStockAmount}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="numberOfPatientsOnTreatmentNextMonth" mode="Opaque" x="952" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="e5d32d95-a523-48e4-845f-b9bf0b7b1ae8">
@@ -543,7 +537,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("numberOfPatientsOnTreatmentNextMonth") != null && str((String) $P{columnLabelKeys}.get("numberOfPatientsOnTreatmentNextMonth")) != null ? str((String) $P{columnLabelKeys}.get("numberOfPatientsOnTreatmentNextMonth")) : (String) $P{columnLabels}.get("numberOfPatientsOnTreatmentNextMonth")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.numberOfPatientsOnTreatmentNextMonth}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="convertedQuantityToIssue" mode="Opaque" x="1068" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="9eee353a-ae4e-4080-b94a-d1e3f6d5887c">
@@ -561,7 +555,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("convertedQuantityToIssue") != null && str((String) $P{columnLabelKeys}.get("convertedQuantityToIssue")) != null ? str((String) $P{columnLabelKeys}.get("convertedQuantityToIssue")) : (String) $P{columnLabels}.get("convertedQuantityToIssue")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.convertedQuantityToIssue}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalRequirement" mode="Opaque" x="981" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="8bbe42c5-8a2f-4ad9-bc38-721aec76bded">
@@ -579,7 +573,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalRequirement") != null && str((String) $P{columnLabelKeys}.get("totalRequirement")) != null ? str((String) $P{columnLabelKeys}.get("totalRequirement")) : (String) $P{columnLabels}.get("totalRequirement")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalRequirement}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="totalQuantityNeededByHf" mode="Opaque" x="1010" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="7bbb1e14-0c77-4a41-b46d-d79c1db1475b">
@@ -597,7 +591,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("totalQuantityNeededByHf") != null && str((String) $P{columnLabelKeys}.get("totalQuantityNeededByHf")) != null ? str((String) $P{columnLabelKeys}.get("totalQuantityNeededByHf")) : (String) $P{columnLabels}.get("totalQuantityNeededByHf")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.totalQuantityNeededByHf}]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Group" evaluationGroup="OrderableDisplayCategory">
 				<reportElement key="quantityToIssue" mode="Opaque" x="1039" y="0" width="29" height="35" backcolor="#CCCCCC" uuid="a41526fc-1510-4e91-854e-5ddbde27ab6e">
@@ -614,7 +608,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("quantityToIssue") != null && str((String) $P{columnLabelKeys}.get("quantityToIssue")) != null ? str((String) $P{columnLabelKeys}.get("quantityToIssue")) : (String) $P{columnLabels}.get("quantityToIssue")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.quantityToIssue}]]></textFieldExpression>
 			</textField>
 			<textField>
 				<reportElement key="dosesPerPatient" mode="Opaque" x="1108" y="0" width="40" height="35" backcolor="#CCCCCC" uuid="16e4af5c-05d3-4dfb-8c3b-afd3a5bf7d2a">
@@ -632,7 +626,7 @@
 				<textElement>
 					<font size="6"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$P{columnLabelKeys}.get("dosesPerPatient") != null && str((String) $P{columnLabelKeys}.get("dosesPerPatient")) != null ? str((String) $P{columnLabelKeys}.get("dosesPerPatient")) : (String) $P{columnLabels}.get("dosesPerPatient")]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$R{report.column.dosesPerPatient}]]></textFieldExpression>
 			</textField>
 		</band>
 	</columnHeader>

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -475,7 +475,6 @@ public class JasperReportsViewServiceTest {
     assertEquals(true, outputParams.get("showInDoses"));
     assertEquals(requisition.getStatus().isAuthorized(),
         outputParams.get("requisitionAuthorized"));
-    Assert.assertTrue(outputParams.get("columnLabels") instanceof Map);
     Assert.assertTrue(outputParams.get("subreport_bytes") instanceof String);
   }
 

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -38,7 +38,6 @@ import java.io.ObjectOutputStream;
 import java.sql.Connection;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,6 +67,7 @@ import org.openlmis.requisition.domain.JasperTemplate;
 import org.openlmis.requisition.domain.RequisitionTemplate;
 import org.openlmis.requisition.domain.RequisitionTemplateDataBuilder;
 import org.openlmis.requisition.domain.requisition.Requisition;
+import org.openlmis.requisition.domain.requisition.RequisitionDataBuilder;
 import org.openlmis.requisition.domain.requisition.RequisitionLineItem;
 import org.openlmis.requisition.dto.FacilityDto;
 import org.openlmis.requisition.dto.GeographicLevelDto;
@@ -75,6 +75,7 @@ import org.openlmis.requisition.dto.GeographicZoneDto;
 import org.openlmis.requisition.dto.MinimalFacilityDto;
 import org.openlmis.requisition.dto.ProcessingPeriodDto;
 import org.openlmis.requisition.dto.ProgramDto;
+import org.openlmis.requisition.dto.RequisitionDto;
 import org.openlmis.requisition.dto.RequisitionReportDto;
 import org.openlmis.requisition.dto.SupervisoryNodeDto;
 import org.openlmis.requisition.exception.JasperReportViewException;
@@ -84,7 +85,9 @@ import org.openlmis.requisition.service.referencedata.FacilityReferenceDataServi
 import org.openlmis.requisition.service.referencedata.GeographicZoneReferenceDataService;
 import org.openlmis.requisition.service.referencedata.PeriodReferenceDataService;
 import org.openlmis.requisition.service.referencedata.ProgramReferenceDataService;
+import org.openlmis.requisition.service.report.ReportService;
 import org.openlmis.requisition.testutils.DtoGenerator;
+import org.openlmis.requisition.testutils.RequisitionReportDtoDataBuilder;
 import org.openlmis.requisition.web.ReportingRateReportDtoBuilder;
 import org.openlmis.requisition.web.RequisitionReportDtoBuilder;
 import org.springframework.data.domain.Page;
@@ -145,6 +148,9 @@ public class JasperReportsViewServiceTest {
   
   @Mock
   private DataSource replicationDataSource; //NOPMD
+
+  @Mock
+  private ReportService reportService;
 
   @InjectMocks
   private JasperReportsViewService service;
@@ -446,24 +452,56 @@ public class JasperReportsViewServiceTest {
   }
 
   @Test
-  public void generateRequisitionReportShouldSetParams() throws Exception {
+  public void generateRequisitionReportShouldDelegateToReportService() throws Exception {
     doReturn(locale).when(service).getLocaleFromService();
     reportParams.put("Requisition", requisition.getId());
 
-    RequisitionReportDto requisitionReportDto = DtoGenerator.of(RequisitionReportDto.class);
+    RequisitionReportDto requisitionReportDto = requisitionReportDto();
     when(requisitionReportDtoBuilder.build(requisition)).thenReturn(requisitionReportDto);
+    when(reportService.generate(eq("requisition"), any(byte[].class), anyMap()))
+        .thenReturn(expectedReportData);
 
-    Boolean showInDoses = true;
-    byte[] reportData = service.generateRequisitionReport(requisition, showInDoses);
-    ArgumentCaptor<Map<String,Object>> paramArg = ArgumentCaptor.forClass(Map.class);
-    verify(service).fillAndExportReport(any(JasperReport.class), paramArg.capture());
+    byte[] reportData = service.generateRequisitionReport(requisition, true, "fr");
+
+    ArgumentCaptor<Map<String, Object>> paramArg = ArgumentCaptor.forClass(Map.class);
+    verify(reportService)
+        .generate(eq("requisition"), any(byte[].class), paramArg.capture());
     Map<String, Object> outputParams = paramArg.getValue();
 
     assertEquals(expectedReportData, reportData);
     assertEquals(DATE_FORMAT, outputParams.get("dateFormat"));
-    assertEquals(createDecimalFormat(), outputParams.get("decimalFormat"));
-    assertEquals(NumberFormat.getCurrencyInstance(locale),
-        outputParams.get("currencyDecimalFormat"));
+    assertEquals("fr", outputParams.get("lang"));
+    assertEquals("pdf", outputParams.get(PARAM_KEY_FORMAT));
+    assertEquals(true, outputParams.get("showInDoses"));
+    assertEquals(requisition.getStatus().isAuthorized(),
+        outputParams.get("requisitionAuthorized"));
+    Assert.assertTrue(outputParams.get("columnLabels") instanceof Map);
+    Assert.assertTrue(outputParams.get("subreport_bytes") instanceof String);
+  }
+
+  @Test
+  public void generateRequisitionReportShouldSendJsonSerializableParams() throws Exception {
+    doReturn(locale).when(service).getLocaleFromService();
+
+    RequisitionReportDto requisitionReportDto = requisitionReportDto();
+    when(requisitionReportDtoBuilder.build(requisition)).thenReturn(requisitionReportDto);
+
+    service.generateRequisitionReport(requisition, true, "en");
+
+    ArgumentCaptor<Map<String, Object>> paramArg = ArgumentCaptor.forClass(Map.class);
+    verify(reportService)
+        .generate(eq("requisition"), any(byte[].class), paramArg.capture());
+
+    // must stay JSON serializable
+    new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsBytes(paramArg.getValue());
+  }
+
+  private RequisitionReportDto requisitionReportDto() {
+    RequisitionDto requisitionDto = new RequisitionDataBuilder().buildAsDto();
+    requisitionDto.setFacility(facility);
+    requisitionDto.setProgram(program);
+    requisitionDto.setProcessingPeriod(period);
+    return new RequisitionReportDtoDataBuilder().withRequisition(requisitionDto).buildAsDto();
   }
 
   private List<FacilityDto> extractFacilitiesFromOutputParams(Map<String, Object> outputParams) {

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -32,6 +32,8 @@ import static org.openlmis.requisition.domain.requisition.RequisitionStatus.INIT
 import static org.openlmis.requisition.domain.requisition.RequisitionStatus.RELEASED;
 import static org.openlmis.requisition.domain.requisition.RequisitionStatus.RELEASED_WITHOUT_ORDER;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -41,18 +43,31 @@ import java.text.DecimalFormatSymbols;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import net.sf.jasperreports.engine.JRDataSource;
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRParameter;
+import net.sf.jasperreports.engine.JRPrintElement;
+import net.sf.jasperreports.engine.JRPrintFrame;
+import net.sf.jasperreports.engine.JRPrintPage;
+import net.sf.jasperreports.engine.JRPrintText;
+import net.sf.jasperreports.engine.JasperFillManager;
 import net.sf.jasperreports.engine.JasperPrint;
 import net.sf.jasperreports.engine.JasperReport;
+import net.sf.jasperreports.engine.data.JRMapCollectionDataSource;
+import net.sf.jasperreports.engine.util.JRLoader;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -106,6 +121,7 @@ public class JasperReportsViewServiceTest {
   private static final String DEFAULT_LOCALE = "en";
   private static final String CURRENCY_LOCALE = "US";
   private static final String PARAM_KEY_FORMAT = "format";
+  private static final String REQUISITION_REPORT_NAME = "requisition";
 
   @Mock
   private ProgramReferenceDataService programReferenceDataService;
@@ -458,14 +474,14 @@ public class JasperReportsViewServiceTest {
 
     RequisitionReportDto requisitionReportDto = requisitionReportDto();
     when(requisitionReportDtoBuilder.build(requisition)).thenReturn(requisitionReportDto);
-    when(reportService.generate(eq("requisition"), any(byte[].class), anyMap()))
+    when(reportService.generate(eq(REQUISITION_REPORT_NAME), any(byte[].class), anyMap()))
         .thenReturn(expectedReportData);
 
     byte[] reportData = service.generateRequisitionReport(requisition, true, "fr");
 
     ArgumentCaptor<Map<String, Object>> paramArg = ArgumentCaptor.forClass(Map.class);
     verify(reportService)
-        .generate(eq("requisition"), any(byte[].class), paramArg.capture());
+        .generate(eq(REQUISITION_REPORT_NAME), any(byte[].class), paramArg.capture());
     Map<String, Object> outputParams = paramArg.getValue();
 
     assertEquals(expectedReportData, reportData);
@@ -489,10 +505,122 @@ public class JasperReportsViewServiceTest {
 
     ArgumentCaptor<Map<String, Object>> paramArg = ArgumentCaptor.forClass(Map.class);
     verify(reportService)
-        .generate(eq("requisition"), any(byte[].class), paramArg.capture());
+        .generate(eq(REQUISITION_REPORT_NAME), any(byte[].class), paramArg.capture());
 
     // must stay JSON serializable
-    new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsBytes(paramArg.getValue());
+    new ObjectMapper().writeValueAsBytes(paramArg.getValue());
+  }
+
+  @Test
+  public void generateRequisitionReportShouldFillTemplateWithTranslatedColumnHeaders()
+      throws Exception {
+    JasperPrint print = fillReportAsReportServiceWould(echoBundle());
+
+    List<String> texts = renderedTexts(print);
+    Assert.assertFalse("nothing was rendered", texts.isEmpty());
+    Assert.assertTrue("line item column headers must come from the bundle, rendered: " + texts,
+        texts.contains(echo("report.column.stockOnHand"))
+            && texts.contains(echo("report.column.totalLossesAndAdjustments")));
+    Assert.assertTrue("main template labels must come from the bundle, rendered: " + texts,
+        texts.contains(echo("report.title.fullSupplyItems")));
+    Assert.assertFalse("a raw bundle key leaked into the rendered report",
+        texts.stream().anyMatch(text -> text.startsWith("report.")));
+  }
+
+  @Test
+  public void generateRequisitionReportShouldRenderBlankHeadersWhenBundleLacksColumnKeys()
+      throws Exception {
+    JasperPrint print = fillReportAsReportServiceWould(emptyBundle());
+
+    List<String> texts = renderedTexts(print);
+    Assert.assertFalse("missing bundle keys must not leak as raw keys, rendered: " + texts,
+        texts.stream().anyMatch(text -> text.contains("report.column.")));
+    Assert.assertFalse("headers render blank rather than failing, rendered: " + texts,
+        texts.contains(echo("report.column.stockOnHand")));
+  }
+
+  private JasperPrint fillReportAsReportServiceWould(ResourceBundle bundle) throws Exception {
+    doReturn(locale).when(service).getLocaleFromService();
+    when(requisitionReportDtoBuilder.build(requisition)).thenReturn(requisitionReportDto());
+
+    service.generateRequisitionReport(requisition, true, "en");
+
+    ArgumentCaptor<byte[]> templateArg = ArgumentCaptor.forClass(byte[].class);
+    ArgumentCaptor<Map<String, Object>> paramArg = ArgumentCaptor.forClass(Map.class);
+    verify(reportService)
+        .generate(eq(REQUISITION_REPORT_NAME), templateArg.capture(), paramArg.capture());
+
+    Map<String, Object> params = new HashMap<>(paramArg.getValue());
+    params.put("subreport",
+        loadReport(Base64.getDecoder().decode((String) params.remove("subreport_bytes"))));
+    Collection<Map<String, ?>> records = (Collection<Map<String, ?>>) params.get("datasource");
+    params.put(JRParameter.REPORT_RESOURCE_BUNDLE, bundle);
+    params.put(JRParameter.REPORT_LOCALE, Locale.ENGLISH);
+
+    return JasperFillManager.fillReport(loadReport(templateArg.getValue()), params,
+        new JRMapCollectionDataSource(records));
+  }
+
+  private JasperReport loadReport(byte[] data) throws JRException {
+    return (JasperReport) JRLoader.loadObject(new ByteArrayInputStream(data));
+  }
+
+  private List<String> renderedTexts(JasperPrint print) {
+    List<String> texts = new ArrayList<>();
+    for (JRPrintPage page : print.getPages()) {
+      collectTexts(page.getElements(), texts);
+    }
+    return texts;
+  }
+
+  private void collectTexts(List<JRPrintElement> elements, List<String> texts) {
+    for (JRPrintElement element : elements) {
+      if (element instanceof JRPrintText) {
+        String text = ((JRPrintText) element).getFullText();
+        if (text != null && !text.trim().isEmpty()) {
+          texts.add(text.trim());
+        }
+      } else if (element instanceof JRPrintFrame) {
+        collectTexts(((JRPrintFrame) element).getElements(), texts);
+      }
+    }
+  }
+
+  private String echo(String key) {
+    return "[" + key + "]";
+  }
+
+  private ResourceBundle echoBundle() {
+    return new ResourceBundle() {
+      @Override
+      protected Object handleGetObject(String key) {
+        return echo(key);
+      }
+
+      @Override
+      public Enumeration<String> getKeys() {
+        return Collections.emptyEnumeration();
+      }
+
+      @Override
+      public boolean containsKey(String key) {
+        return true;
+      }
+    };
+  }
+
+  private ResourceBundle emptyBundle() {
+    return new ResourceBundle() {
+      @Override
+      protected Object handleGetObject(String key) {
+        return null;
+      }
+
+      @Override
+      public Enumeration<String> getKeys() {
+        return Collections.emptyEnumeration();
+      }
+    };
   }
 
   private RequisitionReportDto requisitionReportDto() {

--- a/src/test/java/org/openlmis/requisition/service/report/ReportServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/report/ReportServiceTest.java
@@ -1,0 +1,106 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.report;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openlmis.requisition.service.AuthService;
+import org.openlmis.requisition.service.DataRetrievalException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestOperations;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReportServiceTest {
+
+  private static final String SERVICE_URL = "http://localhost";
+  private static final String REPORT_NAME = "requisition";
+
+  @Mock
+  private RestOperations restTemplate;
+
+  @Mock
+  private AuthService authService;
+
+  @InjectMocks
+  private ReportService reportService;
+
+  private byte[] template = new byte[]{1, 2, 3};
+  private byte[] generated = new byte[]{4, 5, 6};
+  private Map<String, Object> params = new HashMap<>();
+
+  @Before
+  public void setUp() {
+    ReflectionTestUtils.setField(reportService, "restTemplate", restTemplate);
+    ReflectionTestUtils.setField(reportService, "authService", authService);
+    ReflectionTestUtils.setField(reportService, "reportUrl", SERVICE_URL);
+    when(authService.obtainAccessToken()).thenReturn("token");
+    params.put("lang", "fr");
+  }
+
+  @Test
+  public void shouldReturnGeneratedReport() {
+    when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class),
+        eq(byte[].class))).thenReturn(new ResponseEntity<>(generated, HttpStatus.OK));
+
+    assertArrayEquals(generated, reportService.generate(REPORT_NAME, template, params));
+  }
+
+  @Test
+  public void shouldSendNameTemplateAndParamsToReportService() {
+    when(restTemplate.exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class),
+        eq(byte[].class))).thenReturn(new ResponseEntity<>(generated, HttpStatus.OK));
+
+    reportService.generate(REPORT_NAME, template, params);
+
+    ArgumentCaptor<HttpEntity> entity = ArgumentCaptor.forClass(HttpEntity.class);
+    verify(restTemplate).exchange(any(URI.class), eq(HttpMethod.POST), entity.capture(),
+        eq(byte[].class));
+
+    GenerateReportDto sent = (GenerateReportDto) entity.getValue().getBody();
+    assertArrayEquals(template, sent.getTemplate());
+    org.junit.Assert.assertEquals(REPORT_NAME, sent.getName());
+    org.junit.Assert.assertEquals("fr", sent.getParams().get("lang"));
+  }
+
+  @Test(expected = DataRetrievalException.class)
+  public void shouldThrowDataRetrievalExceptionWhenReportServiceFails() {
+    doThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR))
+        .when(restTemplate).exchange(any(URI.class), eq(HttpMethod.POST), any(HttpEntity.class),
+            eq(byte[].class));
+
+    reportService.generate(REPORT_NAME, template, params);
+  }
+}

--- a/src/test/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilderTest.java
+++ b/src/test/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilderTest.java
@@ -117,7 +117,7 @@ public class RequisitionReportPayloadBuilderTest {
     Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
     columns.put(SOH, untouched);
 
-    assertEquals("report.column.requisition." + SOH,
+    assertEquals("report.column." + SOH,
         RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns).get(SOH));
     assertEquals(SOH_LABEL,
         RequisitionReportPayloadBuilder.buildColumnLabels(columns).get(SOH));

--- a/src/test/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilderTest.java
+++ b/src/test/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilderTest.java
@@ -21,18 +21,21 @@ import static org.junit.Assert.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.text.NumberFormat;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.joda.money.CurrencyUnit;
+import org.joda.money.Money;
 import org.junit.Test;
-import org.openlmis.requisition.domain.AvailableRequisitionColumn;
-import org.openlmis.requisition.domain.RequisitionTemplateColumn;
-import org.openlmis.requisition.domain.RequisitionTemplateColumnDataBuilder;
 import org.openlmis.requisition.domain.requisition.RequisitionDataBuilder;
+import org.openlmis.requisition.dto.DispensableDto;
+import org.openlmis.requisition.dto.OrderableDto;
 import org.openlmis.requisition.dto.ProcessingPeriodDto;
 import org.openlmis.requisition.dto.ProgramDto;
+import org.openlmis.requisition.dto.ProgramOrderableDto;
 import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.dto.RequisitionLineItemDto;
 import org.openlmis.requisition.dto.RequisitionReportDto;
 import org.openlmis.requisition.testutils.DtoGenerator;
 import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
@@ -41,8 +44,7 @@ import org.openlmis.requisition.testutils.RequisitionReportDtoDataBuilder;
 public class RequisitionReportPayloadBuilderTest {
 
   private static final String DATE_FORMAT = "dd/MM/yyyy";
-  private static final String SOH = "stockOnHand";
-  private static final String SOH_LABEL = "Stock on hand";
+  private static final String FULL_SUPPLY = "fullSupply";
 
   private final NumberFormat currencyFormat =
       NumberFormat.getCurrencyInstance(new Locale("en", "US"));
@@ -63,30 +65,33 @@ public class RequisitionReportPayloadBuilderTest {
   public void shouldFlattenRequisitionIntoPlainValues() {
     RequisitionReportDto reportDto = reportDto();
 
-    Map<String, Object> record = RequisitionReportPayloadBuilder
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
         .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
 
-    assertEquals(reportDto.getRequisition().getFacility().getName(), record.get("facilityName"));
-    assertEquals(reportDto.getRequisition().getFacility().getCode(), record.get("facilityCode"));
-    assertEquals(reportDto.getRequisition().getProgram().getName(), record.get("programName"));
-    assertEquals(reportDto.getRequisition().getStatus().toString(), record.get("status"));
-    assertTrue(record.get("fullSupply") instanceof List);
-    assertTrue(record.get("nonFullSupply") instanceof List);
+    assertEquals(reportDto.getRequisition().getFacility().getName(),
+        reportRecord.get("facilityName"));
+    assertEquals(reportDto.getRequisition().getFacility().getCode(),
+        reportRecord.get("facilityCode"));
+    assertEquals(reportDto.getRequisition().getProgram().getName(),
+        reportRecord.get("programName"));
+    assertEquals(reportDto.getRequisition().getStatus().toString(), reportRecord.get("status"));
+    assertTrue(reportRecord.get(FULL_SUPPLY) instanceof List);
+    assertTrue(reportRecord.get("nonFullSupply") instanceof List);
   }
 
   @Test
   public void shouldProduceOnlyJsonSerializableValues() throws Exception {
     RequisitionReportDto reportDto = reportDto();
 
-    Map<String, Object> record = RequisitionReportPayloadBuilder
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
         .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
 
-    // the record travels to the report service as JSON
+    // the reportRecord travels to the report service as JSON
     ObjectMapper mapper = new ObjectMapper();
-    Map<?, ?> roundTripped = mapper.readValue(mapper.writeValueAsBytes(record), Map.class);
+    Map<?, ?> roundTripped = mapper.readValue(mapper.writeValueAsBytes(reportRecord), Map.class);
 
-    assertEquals(record.get("facilityName"), roundTripped.get("facilityName"));
-    assertEquals(record.get("status"), roundTripped.get("status"));
+    assertEquals(reportRecord.get("facilityName"), roundTripped.get("facilityName"));
+    assertEquals(reportRecord.get("status"), roundTripped.get("status"));
   }
 
   @Test
@@ -95,52 +100,107 @@ public class RequisitionReportPayloadBuilderTest {
     reportDto.setAuthorizedBy(null);
     reportDto.setAuthorizedDate(null);
 
-    Map<String, Object> record = RequisitionReportPayloadBuilder
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
         .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
 
-    assertNull(record.get("authorizedBy"));
-    assertNull(record.get("authorizedDate"));
+    assertNull(reportRecord.get("authorizedBy"));
+    assertNull(reportRecord.get("authorizedDate"));
   }
 
   @Test
-  public void shouldKeyColumnsThatStillUseTheShippedLabel() {
-    AvailableRequisitionColumn definition = new AvailableRequisitionColumn();
-    definition.setName(SOH);
-    definition.setLabel(SOH_LABEL);
+  public void shouldFlattenLineItemsSoTheTemplateReadsPlainKeys() {
+    RequisitionDto requisition = new RequisitionDataBuilder().buildAsDto();
+    requisition.setFacility(new FacilityDtoDataBuilder().buildAsDto());
+    requisition.setProgram(DtoGenerator.of(ProgramDto.class));
+    requisition.setProcessingPeriod(DtoGenerator.of(ProcessingPeriodDto.class));
 
-    RequisitionTemplateColumn untouched = new RequisitionTemplateColumnDataBuilder()
-        .withName(SOH)
-        .withLabel(SOH_LABEL)
-        .withColumnDefinition(definition)
-        .build();
+    OrderableDto orderable = new OrderableDto();
+    orderable.setProductCode("C100");
+    orderable.setFullProductName("Levora");
+    orderable.setNetContent(10);
+    orderable.setDispensable(new DispensableDto("pack", "each"));
+    orderable.setPrograms(Collections.singleton(new ProgramOrderableDto(
+        requisition.getProgram().getId(), null, "Category A", 1, true, 1, 1,
+        Money.of(CurrencyUnit.USD, 2))));
 
-    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
-    columns.put(SOH, untouched);
+    RequisitionLineItemDto lineItem = new RequisitionLineItemDto();
+    lineItem.setOrderable(orderable);
+    lineItem.setBeginningBalance(100);
+    lineItem.setPricePerPack(Money.of(CurrencyUnit.USD, 2));
+    lineItem.setTotalCost(Money.of(CurrencyUnit.USD, 20));
 
-    assertEquals("report.column." + SOH,
-        RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns).get(SOH));
-    assertEquals(SOH_LABEL,
-        RequisitionReportPayloadBuilder.buildColumnLabels(columns).get(SOH));
+    RequisitionReportDto reportDto = new RequisitionReportDtoDataBuilder()
+        .withRequisition(requisition)
+        .withFullSupply(Collections.singletonList(lineItem))
+        .buildAsDto();
+
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
+    List<?> fullSupply = (List<?>) reportRecord.get(FULL_SUPPLY);
+    Map<?, ?> flattened = (Map<?, ?>) fullSupply.get(0);
+
+    assertEquals("C100", flattened.get("productCode"));
+    assertEquals("Levora", flattened.get("fullProductName"));
+    assertEquals("each", flattened.get("dispensableDisplayUnit"));
+    assertEquals("Category A", flattened.get("categoryDisplayName"));
+    assertEquals(10L, flattened.get("netContent"));
+    assertEquals(100, flattened.get("beginningBalance"));
+    // money is formatted here because the formatter cannot be sent to the report service
+    assertEquals(currencyFormat.format(20), flattened.get("totalCost"));
   }
 
   @Test
-  public void shouldNotKeyColumnsAnAdministratorRenamed() {
-    AvailableRequisitionColumn definition = new AvailableRequisitionColumn();
-    definition.setName(SOH);
-    definition.setLabel(SOH_LABEL);
+  public void shouldReturnEmptyListWhenThereAreNoLineItems() {
+    RequisitionReportDto reportDto = reportDto();
 
-    RequisitionTemplateColumn renamed = new RequisitionTemplateColumnDataBuilder()
-        .withName(SOH)
-        .withLabel("Close bal")
-        .withColumnDefinition(definition)
-        .build();
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
 
-    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
-    columns.put(SOH, renamed);
+    assertTrue(((List<?>) reportRecord.get(FULL_SUPPLY)).isEmpty());
+    assertTrue(((List<?>) reportRecord.get("nonFullSupply")).isEmpty());
+  }
 
-    // a renamed label is printed as entered, in every language
-    assertNull(RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns).get(SOH));
-    assertEquals("Close bal",
-        RequisitionReportPayloadBuilder.buildColumnLabels(columns).get(SOH));
+  @Test
+  public void shouldHandleLineItemsWithoutOrderableOrMoney() {
+    RequisitionDto requisition = new RequisitionDataBuilder().buildAsDto();
+    requisition.setFacility(new FacilityDtoDataBuilder().buildAsDto());
+    requisition.setProgram(DtoGenerator.of(ProgramDto.class));
+    requisition.setProcessingPeriod(DtoGenerator.of(ProcessingPeriodDto.class));
+
+    RequisitionLineItemDto lineItem = new RequisitionLineItemDto();
+    lineItem.setBeginningBalance(5);
+
+    RequisitionReportDto reportDto = new RequisitionReportDtoDataBuilder()
+        .withRequisition(requisition)
+        .withFullSupply(Collections.singletonList(lineItem))
+        .withTotalCost(null)
+        .buildAsDto();
+
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
+    Map<?, ?> flattened = (Map<?, ?>) ((List<?>) reportRecord.get(FULL_SUPPLY)).get(0);
+
+    assertNull(reportRecord.get("totalCost"));
+    assertNull(flattened.get("productCode"));
+    assertNull(flattened.get("dispensableDisplayUnit"));
+    assertEquals(5, flattened.get("beginningBalance"));
+  }
+
+  @Test
+  public void shouldTreatNullLineItemListAsEmpty() {
+    RequisitionDto requisition = new RequisitionDataBuilder().buildAsDto();
+    requisition.setFacility(new FacilityDtoDataBuilder().buildAsDto());
+    requisition.setProgram(DtoGenerator.of(ProgramDto.class));
+    requisition.setProcessingPeriod(DtoGenerator.of(ProcessingPeriodDto.class));
+
+    RequisitionReportDto reportDto = new RequisitionReportDtoDataBuilder()
+        .withRequisition(requisition)
+        .withFullSupply(null)
+        .buildAsDto();
+
+    Map<String, Object> reportRecord = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
+
+    assertTrue(((List<?>) reportRecord.get(FULL_SUPPLY)).isEmpty());
   }
 }

--- a/src/test/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilderTest.java
+++ b/src/test/java/org/openlmis/requisition/service/report/RequisitionReportPayloadBuilderTest.java
@@ -1,0 +1,146 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org.
+ */
+
+package org.openlmis.requisition.service.report;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.text.NumberFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.junit.Test;
+import org.openlmis.requisition.domain.AvailableRequisitionColumn;
+import org.openlmis.requisition.domain.RequisitionTemplateColumn;
+import org.openlmis.requisition.domain.RequisitionTemplateColumnDataBuilder;
+import org.openlmis.requisition.domain.requisition.RequisitionDataBuilder;
+import org.openlmis.requisition.dto.ProcessingPeriodDto;
+import org.openlmis.requisition.dto.ProgramDto;
+import org.openlmis.requisition.dto.RequisitionDto;
+import org.openlmis.requisition.dto.RequisitionReportDto;
+import org.openlmis.requisition.testutils.DtoGenerator;
+import org.openlmis.requisition.testutils.FacilityDtoDataBuilder;
+import org.openlmis.requisition.testutils.RequisitionReportDtoDataBuilder;
+
+public class RequisitionReportPayloadBuilderTest {
+
+  private static final String DATE_FORMAT = "dd/MM/yyyy";
+  private static final String SOH = "stockOnHand";
+  private static final String SOH_LABEL = "Stock on hand";
+
+  private final NumberFormat currencyFormat =
+      NumberFormat.getCurrencyInstance(new Locale("en", "US"));
+
+  /**
+   * The report DTO reaches the builder after RequisitionDtoBuilder has resolved the facility,
+   * program and period, so the fixture has to carry them too.
+   */
+  private RequisitionReportDto reportDto() {
+    RequisitionDto requisition = new RequisitionDataBuilder().buildAsDto();
+    requisition.setFacility(new FacilityDtoDataBuilder().buildAsDto());
+    requisition.setProgram(DtoGenerator.of(ProgramDto.class));
+    requisition.setProcessingPeriod(DtoGenerator.of(ProcessingPeriodDto.class));
+    return new RequisitionReportDtoDataBuilder().withRequisition(requisition).buildAsDto();
+  }
+
+  @Test
+  public void shouldFlattenRequisitionIntoPlainValues() {
+    RequisitionReportDto reportDto = reportDto();
+
+    Map<String, Object> record = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
+
+    assertEquals(reportDto.getRequisition().getFacility().getName(), record.get("facilityName"));
+    assertEquals(reportDto.getRequisition().getFacility().getCode(), record.get("facilityCode"));
+    assertEquals(reportDto.getRequisition().getProgram().getName(), record.get("programName"));
+    assertEquals(reportDto.getRequisition().getStatus().toString(), record.get("status"));
+    assertTrue(record.get("fullSupply") instanceof List);
+    assertTrue(record.get("nonFullSupply") instanceof List);
+  }
+
+  @Test
+  public void shouldProduceOnlyJsonSerializableValues() throws Exception {
+    RequisitionReportDto reportDto = reportDto();
+
+    Map<String, Object> record = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
+
+    // the record travels to the report service as JSON
+    ObjectMapper mapper = new ObjectMapper();
+    Map<?, ?> roundTripped = mapper.readValue(mapper.writeValueAsBytes(record), Map.class);
+
+    assertEquals(record.get("facilityName"), roundTripped.get("facilityName"));
+    assertEquals(record.get("status"), roundTripped.get("status"));
+  }
+
+  @Test
+  public void shouldLeaveMissingUsersAndDatesNull() {
+    RequisitionReportDto reportDto = reportDto();
+    reportDto.setAuthorizedBy(null);
+    reportDto.setAuthorizedDate(null);
+
+    Map<String, Object> record = RequisitionReportPayloadBuilder
+        .buildReportRecord(reportDto, DATE_FORMAT, currencyFormat);
+
+    assertNull(record.get("authorizedBy"));
+    assertNull(record.get("authorizedDate"));
+  }
+
+  @Test
+  public void shouldKeyColumnsThatStillUseTheShippedLabel() {
+    AvailableRequisitionColumn definition = new AvailableRequisitionColumn();
+    definition.setName(SOH);
+    definition.setLabel(SOH_LABEL);
+
+    RequisitionTemplateColumn untouched = new RequisitionTemplateColumnDataBuilder()
+        .withName(SOH)
+        .withLabel(SOH_LABEL)
+        .withColumnDefinition(definition)
+        .build();
+
+    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
+    columns.put(SOH, untouched);
+
+    assertEquals("report.column.requisition." + SOH,
+        RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns).get(SOH));
+    assertEquals(SOH_LABEL,
+        RequisitionReportPayloadBuilder.buildColumnLabels(columns).get(SOH));
+  }
+
+  @Test
+  public void shouldNotKeyColumnsAnAdministratorRenamed() {
+    AvailableRequisitionColumn definition = new AvailableRequisitionColumn();
+    definition.setName(SOH);
+    definition.setLabel(SOH_LABEL);
+
+    RequisitionTemplateColumn renamed = new RequisitionTemplateColumnDataBuilder()
+        .withName(SOH)
+        .withLabel("Close bal")
+        .withColumnDefinition(definition)
+        .build();
+
+    Map<String, RequisitionTemplateColumn> columns = new LinkedHashMap<>();
+    columns.put(SOH, renamed);
+
+    // a renamed label is printed as entered, in every language
+    assertNull(RequisitionReportPayloadBuilder.buildColumnLabelKeys(columns).get(SOH));
+    assertEquals("Close bal",
+        RequisitionReportPayloadBuilder.buildColumnLabels(columns).get(SOH));
+  }
+}

--- a/src/test/java/org/openlmis/requisition/web/ReportsControllerTest.java
+++ b/src/test/java/org/openlmis/requisition/web/ReportsControllerTest.java
@@ -17,6 +17,7 @@ package org.openlmis.requisition.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -73,7 +74,7 @@ public class ReportsControllerTest {
     when(permissionService.canViewRequisition(any(UUID.class)))
         .thenReturn(ValidationResult.notFound("requisition.not.found"));
     // when
-    reportsController.print(UUID.randomUUID(), Boolean.TRUE);
+    reportsController.print(UUID.randomUUID(), Boolean.TRUE, "en");
   }
 
   @Test
@@ -85,12 +86,13 @@ public class ReportsControllerTest {
     when(requisitionRepository.findById(any(UUID.class)))
         .thenReturn(Optional.of(mock(Requisition.class)));
     when(jasperReportsViewService.generateRequisitionReport(
-        any(Requisition.class), anyBoolean())).thenReturn(reportData);
+        any(Requisition.class), anyBoolean(), anyString())).thenReturn(reportData);
     when(permissionService.canViewRequisition(any(UUID.class)))
         .thenReturn(ValidationResult.success());
 
     // when
-    byte[] actualReportData = reportsController.print(UUID.randomUUID(), Boolean.TRUE).getBody();
+    byte[] actualReportData =
+        reportsController.print(UUID.randomUUID(), Boolean.TRUE, "en").getBody();
 
     // then
     assertEquals(reportData, actualReportData);


### PR DESCRIPTION
Task:
https://openlmis.atlassian.net/browse/ODRC-130
Description:
Requisition print no longer fills its own PDF; it sends the compiled template and JSON-safe data to the report service, which applies the shared bundle and logo. New service/report/ package (`BaseReportService`, `ReportService`, `GenerateReportDto`, `RequisitionReportPayloadBuilder`), `lang` param on `/print`, `report.url` property, and both .jrxml templates converted to `$R{}` keys with `msg($R{report.pattern.label}, …)`, a `headerTemplate` logo slot, and column headers translated only when the label is still the shipped default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/136)
<!-- Reviewable:end -->
