### PR TITLE
[ODRC-129] Scale printed requisition font to column count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Upcoming Version / WIP
 ==================
 
+Improvements:
+* [ODRC-129](https://openlmis.atlassian.net/browse/ODRC-129): Scale the printed requisition table font to the number of displayed columns, so sparse requisitions print in a readable size (up to 10pt) while dense ones still fit the page.
+
 8.6.0 / 2026-08-13
 ==================
 

--- a/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
+++ b/src/main/java/org/openlmis/requisition/service/JasperReportsViewService.java
@@ -271,6 +271,9 @@ public class JasperReportsViewService {
       ReportUtils.customizeBandWithTemplateFields(detail, columns, design.getPageWidth(), 9);
       ReportUtils.customizeBandWithTemplateFields(header, columns, design.getPageWidth(), 9);
 
+      ReportUtils.applyColumnCountFont(detail);
+      ReportUtils.applyColumnCountFont(header);
+
       return design;
     } catch (IOException err) {
       throw new JasperReportViewException(err, ERROR_IO, err.getMessage());

--- a/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
+++ b/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
@@ -31,11 +31,21 @@ import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 import net.sf.jasperreports.engine.JRBand;
 import net.sf.jasperreports.engine.design.JRDesignTextField;
+import net.sf.jasperreports.engine.type.StretchTypeEnum;
 import org.openlmis.requisition.domain.RequisitionTemplateColumn;
 import org.openlmis.requisition.domain.requisition.RequisitionStatus;
 import org.springframework.context.i18n.LocaleContextHolder;
 
 public final class ReportUtils {
+
+  // Print font size for the requisition line table, chosen by how many columns are displayed:
+  // few columns print large and readable, dense tables step down so they still fit the page width.
+  private static final int READABLE_FONT_SIZE = 10;
+  private static final int MEDIUM_FONT_SIZE = 9;
+  private static final int COMPACT_FONT_SIZE = 8;
+  private static final int MAX_COLUMNS_FOR_READABLE_FONT = 12;
+  private static final int MAX_COLUMNS_FOR_MEDIUM_FONT = 14;
+
   private ReportUtils() {
     throw new UnsupportedOperationException();
   }
@@ -96,10 +106,7 @@ public final class ReportUtils {
     List<String> foundTemplateKeys = columns.keySet().stream()
         .filter(key -> band.getElementByKey(key) != null)
         .collect(Collectors.toList());
-    List<JRDesignTextField> foundColumns = band.getChildren().stream()
-        .filter(child -> child instanceof JRDesignTextField)
-        .map(child -> (JRDesignTextField)child)
-        .collect(Collectors.toList());
+    List<JRDesignTextField> foundColumns = textFields(band);
 
     double widthMultipier = getWidthMultipier(width, margin, foundTemplateKeys, foundColumns);
 
@@ -114,6 +121,43 @@ public final class ReportUtils {
 
     fillWidthGap(prevField, width, margin);
     removeSpareColumns(band, foundColumns, foundTemplateKeys);
+  }
+
+  /**
+   * Scales the font of an already customized band to how many columns it ended up with, so a
+   * requisition with few columns prints in a readable size while a dense one still fits the page.
+   * Fields are allowed to grow vertically so the larger text does not get clipped.
+   *
+   * @param band a band already reduced to its displayed columns.
+   */
+  public static void applyColumnCountFont(JRBand band) {
+    List<JRDesignTextField> fields = textFields(band);
+
+    int fontSize = fontSizeForColumnCount(fields.size());
+    for (JRDesignTextField field : fields) {
+      field.setFontSize((float) fontSize);
+      // let a cell grow when its larger text wraps, and keep every cell in the row the same
+      // height so the column borders stay aligned
+      field.setStretchWithOverflow(true);
+      field.setStretchType(StretchTypeEnum.RELATIVE_TO_TALLEST_OBJECT);
+    }
+  }
+
+  static int fontSizeForColumnCount(int columnCount) {
+    if (columnCount <= MAX_COLUMNS_FOR_READABLE_FONT) {
+      return READABLE_FONT_SIZE;
+    }
+    if (columnCount <= MAX_COLUMNS_FOR_MEDIUM_FONT) {
+      return MEDIUM_FONT_SIZE;
+    }
+    return COMPACT_FONT_SIZE;
+  }
+
+  private static List<JRDesignTextField> textFields(JRBand band) {
+    return band.getChildren().stream()
+        .filter(child -> child instanceof JRDesignTextField)
+        .map(child -> (JRDesignTextField) child)
+        .collect(Collectors.toList());
   }
 
   private static double getWidthMultipier(int width, int margin, List<String> foundTemplateKeys,

--- a/src/main/resources/jasperTemplates/requisitionLines.jrxml
+++ b/src/main/resources/jasperTemplates/requisitionLines.jrxml
@@ -634,7 +634,7 @@
 		<band height="25" splitType="Stretch">
 			<property name="com.jaspersoft.studio.unit.height" value="px"/>
 			<rectangle>
-				<reportElement x="9" y="0" width="1142" height="25" backcolor="#DEDEDE" uuid="2a65185a-b9a9-41e7-92b5-f269c9622440">
+				<reportElement x="9" y="0" width="1142" height="25" backcolor="#DEDEDE" stretchType="RelativeToBandHeight" uuid="2a65185a-b9a9-41e7-92b5-f269c9622440">
 					<property name="com.jaspersoft.studio.unit.y" value="px"/>
 					<property name="com.jaspersoft.studio.unit.height" value="px"/>
 					<property name="com.jaspersoft.studio.unit.x" value="px"/>

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -539,6 +539,44 @@ public class JasperReportsViewServiceTest {
         texts.contains(echo("report.column.stockOnHand")));
   }
 
+  @Test
+  public void generateRequisitionReportShouldScaleColumnHeaderFontEndToEnd() throws Exception {
+    JasperPrint print = fillReportAsReportServiceWould(echoBundle());
+
+    List<JRPrintText> headers = new ArrayList<>();
+    for (JRPrintPage page : print.getPages()) {
+      collectColumnHeaders(page.getElements(), headers);
+    }
+
+    Assert.assertFalse("no column headers were rendered", headers.isEmpty());
+
+    float fontSize = headers.get(0).getFontsize();
+    Assert.assertTrue("font is scaled up from the old hard-coded 6pt default", fontSize > 6f);
+    Assert.assertTrue("font is one of the column-count sizes: " + fontSize,
+        fontSize == 8f || fontSize == 9f || fontSize == 10f);
+    headers.forEach(header -> Assert.assertEquals("all column headers share one size",
+        fontSize, header.getFontsize(), 0f));
+
+    // RELATIVE_TO_TALLEST_OBJECT keeps every header cell the same height even when a long label
+    // wraps, so the column borders stay aligned
+    int height = headers.get(0).getHeight();
+    headers.forEach(header -> Assert.assertEquals("all column headers share one height",
+        height, header.getHeight()));
+  }
+
+  private void collectColumnHeaders(List<JRPrintElement> elements, List<JRPrintText> headers) {
+    for (JRPrintElement element : elements) {
+      if (element instanceof JRPrintText) {
+        String text = ((JRPrintText) element).getFullText();
+        if (text != null && text.startsWith("[report.column.")) {
+          headers.add((JRPrintText) element);
+        }
+      } else if (element instanceof JRPrintFrame) {
+        collectColumnHeaders(((JRPrintFrame) element).getElements(), headers);
+      }
+    }
+  }
+
   private JasperPrint fillReportAsReportServiceWould(ResourceBundle bundle) throws Exception {
     doReturn(locale).when(service).getLocaleFromService();
     when(requisitionReportDtoBuilder.build(requisition)).thenReturn(requisitionReportDto());

--- a/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
+++ b/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
@@ -231,6 +231,46 @@ public class ReportUtilsTest {
     assertEquals(FIELD_THREE_WIDTH, fieldThree.getWidth(), DELTA);
   }
 
+  @Test
+  public void shouldPickFontSizeByColumnCount() {
+    assertEquals(10, ReportUtils.fontSizeForColumnCount(1));
+    assertEquals(10, ReportUtils.fontSizeForColumnCount(12));
+    assertEquals(9, ReportUtils.fontSizeForColumnCount(13));
+    assertEquals(9, ReportUtils.fontSizeForColumnCount(14));
+    assertEquals(8, ReportUtils.fontSizeForColumnCount(15));
+    assertEquals(8, ReportUtils.fontSizeForColumnCount(20));
+  }
+
+  @Test
+  public void shouldApplyLargeFontAndStretchWhenFewColumns() {
+    JRDesignTextField fieldOne = getField(ADJUSTED_CONSUMPTION, FIELD_ONE_WIDTH);
+    JRDesignTextField fieldTwo = getField(AVERAGE_CONSUMPTION, FIELD_TWO_WIDTH);
+    JRBand jrBand = mock(JRBand.class);
+    when(jrBand.getChildren())
+        .thenReturn(new LinkedList<>(Arrays.asList(fieldOne, fieldTwo)));
+
+    ReportUtils.applyColumnCountFont(jrBand);
+
+    assertEquals(10f, fieldOne.getFontsize(), 0f);
+    assertEquals(10f, fieldTwo.getFontsize(), 0f);
+    assertTrue(fieldOne.isStretchWithOverflow());
+    assertTrue(fieldTwo.isStretchWithOverflow());
+  }
+
+  @Test
+  public void shouldApplySmallestFontWhenTableIsDense() {
+    LinkedList<JRChild> fields = new LinkedList<>();
+    for (int i = 0; i < 15; i++) {
+      fields.add(getField("column" + i, FIELD_ONE_WIDTH));
+    }
+    JRBand jrBand = mock(JRBand.class);
+    when(jrBand.getChildren()).thenReturn(fields);
+
+    ReportUtils.applyColumnCountFont(jrBand);
+
+    fields.forEach(field -> assertEquals(8f, ((JRDesignTextField) field).getFontsize(), 0f));
+  }
+
   private void stubDisplay(RequisitionTemplateColumn column, int displayOrder) {
     when(column.getDisplayOrder()).thenReturn(displayOrder);
     when(column.getIsDisplayed()).thenReturn(true);


### PR DESCRIPTION
## What

The printed requisition table used a fixed 6pt font, which facilities said was too small to read on a physical printout (ODRC-129). The font now scales with how many columns the template shows: few columns print at 10pt, and denser tables step down (9pt, then 8pt) so they still fit across the page.

A flat increase wasn't an option, since the requisition template is configurable and can show anywhere from about 5 to 15 columns, so the size comes from the column count.

## How

- `ReportUtils.applyColumnCountFont` sets the font from the number of displayed columns, and lets a cell grow when a bigger label wraps while keeping every cell in a row the same height so the borders stay aligned.
- It runs on both the header and the detail band during the existing subreport customization, so the whole change stays inside openlmis-requisition (nothing needed in the report service or the UI).
- The alternating row background now stretches with the row.

## Scope and a heads-up

- Only the line table changes. The header and summary labels are left as they are.
- On a 15-column template the font ends up below 10pt on purpose: a 10pt long header does not fit at that width, so full readability and full column density can't both hold. Worth confirming that trade-off with the reporter.

## Testing

- Unit tests for the column-count to font-size mapping and the styling helper.
- Extended the report-service fill test to render a real report and check that the column headers use the scaled font and keep an equal height when labels wrap.

Jira: https://openlmis.atlassian.net/browse/ODRC-129

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/137)
<!-- Reviewable:end -->
