### PR TITLE
[ODRC-129] Increase the requisition print font a step further

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Upcoming Version / WIP
 * [OLMIS-8176](https://openlmis.atlassian.net/browse/OLMIS-8176): Added a Pack Size column to the requisition printed report.
 
 Improvements:
-* [ODRC-129](https://openlmis.atlassian.net/browse/ODRC-129): Scale the printed requisition table font to the number of displayed columns, so sparse requisitions print in a readable size (up to 10pt) while dense ones still fit the page.
+* [ODRC-129](https://openlmis.atlassian.net/browse/ODRC-129): Scale the printed requisition table font to the number of displayed columns (10pt for the densest tables up to 12pt for sparse ones) so it is readable while still fitting the page.
 
 8.6.0 / 2026-08-13
 ==================

--- a/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
+++ b/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
@@ -44,9 +44,9 @@ public final class ReportUtils {
 
   // Print font size for the requisition line table, chosen by how many columns are displayed:
   // few columns print large and readable, dense tables step down so they still fit the page width.
-  private static final int READABLE_FONT_SIZE = 10;
-  private static final int MEDIUM_FONT_SIZE = 9;
-  private static final int COMPACT_FONT_SIZE = 8;
+  private static final int READABLE_FONT_SIZE = 12;
+  private static final int MEDIUM_FONT_SIZE = 11;
+  private static final int COMPACT_FONT_SIZE = 10;
   private static final int MAX_COLUMNS_FOR_READABLE_FONT = 12;
   private static final int MAX_COLUMNS_FOR_MEDIUM_FONT = 14;
 

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -553,7 +553,7 @@ public class JasperReportsViewServiceTest {
     float fontSize = headers.get(0).getFontsize();
     Assert.assertTrue("font is scaled up from the old hard-coded 6pt default", fontSize > 6f);
     Assert.assertTrue("font is one of the column-count sizes: " + fontSize,
-        fontSize == 8f || fontSize == 9f || fontSize == 10f);
+        fontSize == 10f || fontSize == 11f || fontSize == 12f);
     headers.forEach(header -> Assert.assertEquals("all column headers share one size",
         fontSize, header.getFontsize(), 0f));
 

--- a/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
+++ b/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
@@ -319,12 +319,12 @@ public class ReportUtilsTest {
 
   @Test
   public void shouldPickFontSizeByColumnCount() {
-    assertEquals(10, ReportUtils.fontSizeForColumnCount(1));
-    assertEquals(10, ReportUtils.fontSizeForColumnCount(12));
-    assertEquals(9, ReportUtils.fontSizeForColumnCount(13));
-    assertEquals(9, ReportUtils.fontSizeForColumnCount(14));
-    assertEquals(8, ReportUtils.fontSizeForColumnCount(15));
-    assertEquals(8, ReportUtils.fontSizeForColumnCount(20));
+    assertEquals(12, ReportUtils.fontSizeForColumnCount(1));
+    assertEquals(12, ReportUtils.fontSizeForColumnCount(12));
+    assertEquals(11, ReportUtils.fontSizeForColumnCount(13));
+    assertEquals(11, ReportUtils.fontSizeForColumnCount(14));
+    assertEquals(10, ReportUtils.fontSizeForColumnCount(15));
+    assertEquals(10, ReportUtils.fontSizeForColumnCount(20));
   }
 
   @Test
@@ -337,8 +337,8 @@ public class ReportUtilsTest {
 
     ReportUtils.applyColumnCountFont(jrBand);
 
-    assertEquals(10f, fieldOne.getFontsize(), 0f);
-    assertEquals(10f, fieldTwo.getFontsize(), 0f);
+    assertEquals(12f, fieldOne.getFontsize(), 0f);
+    assertEquals(12f, fieldTwo.getFontsize(), 0f);
     assertTrue(fieldOne.isStretchWithOverflow());
     assertTrue(fieldTwo.isStretchWithOverflow());
   }
@@ -354,7 +354,7 @@ public class ReportUtilsTest {
 
     ReportUtils.applyColumnCountFont(jrBand);
 
-    fields.forEach(field -> assertEquals(8f, ((JRDesignTextField) field).getFontsize(), 0f));
+    fields.forEach(field -> assertEquals(10f, ((JRDesignTextField) field).getFontsize(), 0f));
   }
 
   private void stubDisplay(RequisitionTemplateColumn column, int displayOrder) {


### PR DESCRIPTION
## What

Follow-up to #137 after QA. The reporter confirmed the requisition print font got bigger but asked for it to be larger still, so this bumps each column-count step up by 2pt.

Before it was 10 / 9 / 8pt. Now it is 12pt for few columns, 11pt for medium, and 10pt as the floor for the densest tables. Every requisition now prints at 10pt or larger, and a typical one (around 12 columns, like the reporter's) prints at 12pt.

## How

One change to the size thresholds in `ReportUtils.fontSizeForColumnCount` (the constants), plus the updated test expectations. The scaling and layout mechanics from #137 are untouched, so headers still wrap and the cells keep an equal height at the larger size.

## Testing

- Unit tests for the count-to-size mapping updated to the new sizes.
- The report-service fill test still checks the rendered column headers are scaled and keep an equal height.
- Rendered the dense (10pt) and sparse (12pt) cases locally to confirm nothing clips and the rows stay aligned.

Jira: https://openlmis.atlassian.net/browse/ODRC-129

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/138)
<!-- Reviewable:end -->
