### PR TITLE
[ODRC-129] Add an 8pt tier for very dense requisition tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Upcoming Version / WIP
 * [OLMIS-8176](https://openlmis.atlassian.net/browse/OLMIS-8176): Added a Pack Size column to the requisition printed report.
 
 Improvements:
-* [ODRC-129](https://openlmis.atlassian.net/browse/ODRC-129): Scale the printed requisition table font to the number of displayed columns (10pt for the densest tables up to 12pt for sparse ones) so it is readable while still fitting the page.
+* [ODRC-129](https://openlmis.atlassian.net/browse/ODRC-129): Scale the printed requisition table font to the number of displayed columns (8pt for the very densest tables, scaling up to 12pt for sparse ones) so it is readable while still fitting the page.
 
 8.6.0 / 2026-08-13
 ==================

--- a/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
+++ b/src/main/java/org/openlmis/requisition/utils/ReportUtils.java
@@ -47,8 +47,10 @@ public final class ReportUtils {
   private static final int READABLE_FONT_SIZE = 12;
   private static final int MEDIUM_FONT_SIZE = 11;
   private static final int COMPACT_FONT_SIZE = 10;
+  private static final int SMALL_FONT_SIZE = 8;
   private static final int MAX_COLUMNS_FOR_READABLE_FONT = 12;
   private static final int MAX_COLUMNS_FOR_MEDIUM_FONT = 14;
+  private static final int MAX_COLUMNS_FOR_COMPACT_FONT = 19;
 
   private ReportUtils() {
     throw new UnsupportedOperationException();
@@ -156,7 +158,10 @@ public final class ReportUtils {
     if (columnCount <= MAX_COLUMNS_FOR_MEDIUM_FONT) {
       return MEDIUM_FONT_SIZE;
     }
-    return COMPACT_FONT_SIZE;
+    if (columnCount <= MAX_COLUMNS_FOR_COMPACT_FONT) {
+      return COMPACT_FONT_SIZE;
+    }
+    return SMALL_FONT_SIZE;
   }
 
   private static List<JRDesignTextField> textFields(JRBand band) {

--- a/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
+++ b/src/test/java/org/openlmis/requisition/service/JasperReportsViewServiceTest.java
@@ -553,7 +553,7 @@ public class JasperReportsViewServiceTest {
     float fontSize = headers.get(0).getFontsize();
     Assert.assertTrue("font is scaled up from the old hard-coded 6pt default", fontSize > 6f);
     Assert.assertTrue("font is one of the column-count sizes: " + fontSize,
-        fontSize == 10f || fontSize == 11f || fontSize == 12f);
+        fontSize == 8f || fontSize == 10f || fontSize == 11f || fontSize == 12f);
     headers.forEach(header -> Assert.assertEquals("all column headers share one size",
         fontSize, header.getFontsize(), 0f));
 

--- a/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
+++ b/src/test/java/org/openlmis/requisition/utils/ReportUtilsTest.java
@@ -324,7 +324,9 @@ public class ReportUtilsTest {
     assertEquals(11, ReportUtils.fontSizeForColumnCount(13));
     assertEquals(11, ReportUtils.fontSizeForColumnCount(14));
     assertEquals(10, ReportUtils.fontSizeForColumnCount(15));
-    assertEquals(10, ReportUtils.fontSizeForColumnCount(20));
+    assertEquals(10, ReportUtils.fontSizeForColumnCount(19));
+    assertEquals(8, ReportUtils.fontSizeForColumnCount(20));
+    assertEquals(8, ReportUtils.fontSizeForColumnCount(25));
   }
 
   @Test
@@ -344,7 +346,7 @@ public class ReportUtilsTest {
   }
 
   @Test
-  public void shouldApplySmallestFontWhenTableIsDense() {
+  public void shouldApplyCompactFontWhenTableIsDense() {
     LinkedList<JRChild> fields = new LinkedList<>();
     for (int i = 0; i < 15; i++) {
       fields.add(getField("column" + i, FIELD_ONE_WIDTH));
@@ -355,6 +357,20 @@ public class ReportUtilsTest {
     ReportUtils.applyColumnCountFont(jrBand);
 
     fields.forEach(field -> assertEquals(10f, ((JRDesignTextField) field).getFontsize(), 0f));
+  }
+
+  @Test
+  public void shouldApplySmallestFontWhenTableIsVeryDense() {
+    LinkedList<JRChild> fields = new LinkedList<>();
+    for (int i = 0; i < 20; i++) {
+      fields.add(getField("column" + i, FIELD_ONE_WIDTH));
+    }
+    JRBand jrBand = mock(JRBand.class);
+    when(jrBand.getChildren()).thenReturn(fields);
+
+    ReportUtils.applyColumnCountFont(jrBand);
+
+    fields.forEach(field -> assertEquals(8f, ((JRDesignTextField) field).getFontsize(), 0f));
   }
 
   private void stubDisplay(RequisitionTemplateColumn column, int displayOrder) {


### PR DESCRIPTION
## What

Adds a fourth, smallest font tier for very dense requisition tables. A table with 20 or more columns now prints at 8pt instead of 10pt, so an extremely wide template still fits the page.

Builds on #138 (already merged to master), which raised the sizes to 12/11/10. The full mapping is now:

- up to 12 columns: 12pt
- 13 to 14: 11pt
- 15 to 19: 10pt
- 20 or more: 8pt

## Why

QA asked for a smaller minimum so the densest templates do not overflow. This trades the "10pt everywhere" floor for fit on the very widest tables; a typical requisition (around 12 columns) is unaffected and still prints at 12pt.

## How

One new size constant and threshold in `ReportUtils.fontSizeForColumnCount`, plus test coverage for the new tier. The scaling and layout mechanics are unchanged.

## Testing

- Unit tests for the mapping boundaries (19 columns to 10pt, 20 columns to 8pt) and the styling helper.
- The report-service fill test still checks the rendered column headers are scaled and keep an equal height.

Jira: https://openlmis.atlassian.net/browse/ODRC-129

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OpenLMIS/openlmis-requisition/139)
<!-- Reviewable:end -->
